### PR TITLE
fix: generate diagrams for logic blocks with only one state

### DIFF
--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/SingleState.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/SingleState.cs
@@ -1,0 +1,25 @@
+namespace Chickensoft.LogicBlocks.Generator.Tests;
+
+[StateMachine]
+public class SingleState :
+  LogicBlock<SingleState.Input, SingleState.State, SingleState.Output> {
+  public override State GetInitialState(Context context) => new(Context);
+
+  public abstract record Input {
+    public record MyInput : Input { }
+  }
+  public record State : StateLogic, IGet<Input.MyInput> {
+    public State(Context context) : base(context) {
+      OnEnter<State>((previous) => Context.Output(new Output.MyOutput()));
+      OnExit<State>((next) => Context.Output(new Output.MyOutput()));
+    }
+
+    public State On(Input.MyInput input) {
+      Context.Output(new Output.MyOutput());
+      return this;
+    }
+  }
+  public abstract record Output {
+    public record MyOutput : Output { }
+  }
+}

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/SingleState.g.puml
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/SingleState.g.puml
@@ -1,0 +1,11 @@
+@startuml SingleState
+state "SingleState State" as Chickensoft_LogicBlocks_Generator_Tests_SingleState_State {
+  Chickensoft_LogicBlocks_Generator_Tests_SingleState_State : OnEnter → MyOutput
+  Chickensoft_LogicBlocks_Generator_Tests_SingleState_State : OnExit → MyOutput
+  Chickensoft_LogicBlocks_Generator_Tests_SingleState_State : OnMyInput → MyOutput
+}
+
+Chickensoft_LogicBlocks_Generator_Tests_SingleState_State --> Chickensoft_LogicBlocks_Generator_Tests_SingleState_State : MyInput
+
+[*] --> Chickensoft_LogicBlocks_Generator_Tests_SingleState_State
+@enduml

--- a/Chickensoft.LogicBlocks.Generator/Chickensoft.LogicBlocks.Generator.csproj
+++ b/Chickensoft.LogicBlocks.Generator/Chickensoft.LogicBlocks.Generator.csproj
@@ -11,7 +11,7 @@
     <NoWarn>NU5128</NoWarn>
 
     <Title>LogicBlocks Generator</Title>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Description></Description>
     <Copyright>© 2023 Chickensoft Games</Copyright>
     <Authors>Chickensoft</Authors>

--- a/Chickensoft.LogicBlocks.Generator/src/LogicBlocksGenerator.cs
+++ b/Chickensoft.LogicBlocks.Generator/src/LogicBlocksGenerator.cs
@@ -285,9 +285,12 @@ public class LogicBlocksGenerator :
       return graph;
     }
 
-    root.Children.AddRange(subtypesByBaseType[root.BaseId]
-      .Select((stateType) => buildGraph(stateType, stateBaseType))
-    );
+    if (subtypesByBaseType.ContainsKey(root.BaseId)) {
+      // Only try to build graph of subtypes if there are any.
+      root.Children.AddRange(subtypesByBaseType[root.BaseId]
+        .Select((stateType) => buildGraph(stateType, stateBaseType))
+      );
+    }
 
     foreach (var state in stateGraphsById.Values) {
       var statesAndOutputs = GetStatesAndOutputs(

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ public class LightSwitch :
 
   public abstract record State(Context Context) : StateLogic(Context) {
     public record On(Context Context) : State(Context), IGet<Input.Toggle> {
-      State IGet<Input.Toggle>.On(Input.Toggle input) => new Off(Context);
+      public State On(Input.Toggle input) => new Off(Context);
     }
 
     public record Off(Context Context) : State(Context), IGet<Input.Toggle> {
-      State IGet<Input.Toggle>.On(Input.Toggle input) => new On(Context);
+      public State On(Input.Toggle input) => new On(Context);
     }
   }
 
@@ -66,15 +66,18 @@ Finally, the logic blocks source generator can be used to produce a UML diagram 
 
 ## 👩‍🏫 Examples
 
-- [**`LightSwitch.cs`**](Chickensoft.LogicBlocks.Generator.Tests/LightSwitch.cs)
+- [**`LightSwitch.cs`**](Chickensoft.LogicBlocks.Generator.Tests/test_cases/LightSwitch.cs)
 
   ![LightSwitch state diagram](docs/light_switch.png)
-- [**`Heater.cs`**](Chickensoft.LogicBlocks.Generator.Tests/Heater.cs)
 
-  ![Heater State Diagram](docs/heater.png)
-- [**`ToasterOven.cs`**](Chickensoft.LogicBlocks.Generator.Tests/ToasterOven.cs)
+- [**`Heater.cs`**](Chickensoft.LogicBlocks.Generator.Tests/test_cases/Heater.cs)
+
+  ![Heater  State Diagram](docs/heater.png)
+
+- [**`ToasterOven.cs`**](Chickensoft.LogicBlocks.Generator.Tests/test_cases/ToasterOven.cs)
 
   ![Toaster Oven State Diagram](docs/toaster_oven.png)
+
 - [**`VendingMachine.cs`**](Chickensoft.LogicBlocks.Example/VendingMachine.cs)
 
   The Vending Machine example shows a fully built CLI app that simulates a vending machine, complete with timers, inventory, and cash return.
@@ -142,10 +145,10 @@ You can find the latest version of LogicBlocks on [nuget][logic-blocks-nuget].
 dotnet add package Chickensoft.LogicBlocks
 ```
 
-To use the LogicBlocks source generator, add the following to your `.csproj` file. Make sure to replace `2.0.0` with the latest version of the [LogicBlocks generator from nuget][logic-blocks-gen-nuget].
+To use the LogicBlocks source generator, add the following to your `.csproj` file. Make sure to replace `2.0.1` with the latest version of the [LogicBlocks generator from nuget][logic-blocks-gen-nuget].
 
 ```xml
-  <PackageReference Include="Chickensoft.LogicBlocks.Generator" Version="2.0.0" PrivateAssets="all" OutputItemType="analyzer" />
+  <PackageReference Include="Chickensoft.LogicBlocks.Generator" Version="2.0.1" PrivateAssets="all" OutputItemType="analyzer" />
 ```
 
 Once you have both packages installed, you can force diagram generation with the following command in your project:
@@ -230,8 +233,7 @@ We'll go ahead and write out the first two states, `Off` and `Idle`:
     public record Off(
       Context Context, double TargetTemp
     ) : State(Context, TargetTemp), IGet<Input.TurnOn> {
-      State IGet<Input.TurnOn>.On(Input.TurnOn input) =>
-        new Heating(Context, TargetTemp);
+      public State On(Input.TurnOn input) => new Heating(Context, TargetTemp);
     }
 
     public record Idle(Context Context, double TargetTemp) :
@@ -265,17 +267,15 @@ In the case of `Off`, we only need to handle the `TurnOn` event. Input handlers 
         );
       }
 
-      State IGet<Input.TurnOff>.On(Input.TurnOff input)
-        => new Off(Context, TargetTemp);
+      public State On(Input.TurnOff input) => new Off(Context, TargetTemp);
 
-      State IGet<Input.AirTempSensorChanged>.On(
-        Input.AirTempSensorChanged input
-      ) => input.AirTemp >= TargetTemp
+      public State On(Input.AirTempSensorChanged input) => input.AirTemp >= TargetTemp
         ? new Idle(Context, TargetTemp)
         : this;
 
-      State IGet<Input.TargetTempChanged>.On(Input.TargetTempChanged input)
-        => this with { TargetTemp = input.Temp };
+      public State On(Input.TargetTempChanged input) => this with {
+        TargetTemp = input.Temp
+      };
 
       private void OnTemperatureChanged(double airTemp) {
         Context.Input(new Input.AirTempSensorChanged(airTemp));
@@ -316,7 +316,7 @@ Finally, we have to override the method that returns the initial state of the lo
 
 ### Using Our LogicBlock
 
-In case you missed it above, the completed space heater example is available  in [`Heater.cs`](Chickensoft.LogicBlocks.Generator.Tests/Heater.cs).
+In case you missed it above, the completed space heater example is available  in [`Heater.cs`](Chickensoft.LogicBlocks.Generator.Tests/test_cases/Heater.cs).
 
 To use our logic block, we'd have to first make a temperature sensor that conforms to the `ITemperatureSensor` interface that we never showed.
 


### PR DESCRIPTION
Diagram generator had a simple bug where it would not generate diagrams for logic blocks that only used a single state. This fixes it and the broken links in the Readme.