### PR TITLE
feat: allow logic blocks to be tested

### DIFF
--- a/Chickensoft.LogicBlocks.Example/VendingMachine.cs
+++ b/Chickensoft.LogicBlocks.Example/VendingMachine.cs
@@ -13,10 +13,10 @@ public partial class VendingMachine {
     public record VendingCompleted : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context) {
+  public abstract record State(IContext Context) : StateLogic(Context) {
     public record Idle : State,
       IGet<Input.SelectionEntered>, IGet<Input.PaymentReceived> {
-      public Idle(Context context) : base(context) {
+      public Idle(IContext context) : base(context) {
         OnEnter<Idle>((previous) => context.Output(
           new Output.ClearTransactionTimeOutTimer()
         ));
@@ -49,7 +49,7 @@ public partial class VendingMachine {
       public int AmountReceived { get; }
 
       public TransactionActive(
-        Context context, ItemType type, int price, int amountReceived
+        IContext context, ItemType type, int price, int amountReceived
       ) : base(context) {
         Type = type;
         Price = price;
@@ -95,7 +95,7 @@ public partial class VendingMachine {
       public record Started : TransactionActive,
         IGet<Input.SelectionEntered> {
         public Started(
-          Context context, ItemType type, int price, int amountReceived
+          IContext context, ItemType type, int price, int amountReceived
         ) : base(context, type, price, amountReceived) {
           OnEnter<Started>(
             (previous) => context.Output(new Output.TransactionStarted())
@@ -115,7 +115,7 @@ public partial class VendingMachine {
       }
 
       public record PaymentPending(
-        Context Context, ItemType Type, int Price, int AmountReceived
+        IContext Context, ItemType Type, int Price, int AmountReceived
       ) : TransactionActive(Context, Type, Price, AmountReceived);
     }
 
@@ -123,7 +123,7 @@ public partial class VendingMachine {
       public ItemType Type { get; }
       public int Price { get; }
 
-      public Vending(Context context, ItemType type, int price) :
+      public Vending(IContext context, ItemType type, int price) :
         base(context) {
         Type = type;
         Price = price;
@@ -171,7 +171,7 @@ public partial class VendingMachine :
     Set(stock);
   }
 
-  public override State GetInitialState(Context context)
+  public override State GetInitialState(IContext context)
     => new State.Idle(context);
 }
 

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/Heater.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/Heater.cs
@@ -21,7 +21,7 @@ public class Heater :
     Set(tempSensor);
   }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.Off(context, 72.0);
 
   public abstract record Input {
@@ -31,23 +31,23 @@ public class Heater :
     public record AirTempSensorChanged(double AirTemp) : Input;
   }
 
-  public abstract record State(Context Context, double TargetTemp)
+  public abstract record State(IContext Context, double TargetTemp)
     : StateLogic(Context) {
     public record Off(
-      Context Context, double TargetTemp
+      IContext Context, double TargetTemp
     ) : State(Context, TargetTemp), IGet<Input.TurnOn> {
       State IGet<Input.TurnOn>.On(Input.TurnOn input) =>
         new Heating(Context, TargetTemp);
     }
 
-    public record Idle(Context Context, double TargetTemp) :
+    public record Idle(IContext Context, double TargetTemp) :
       State(Context, TargetTemp);
 
     public record Heating : State,
       IGet<Input.TurnOff>,
       IGet<Input.AirTempSensorChanged>,
       IGet<Input.TargetTempChanged> {
-      public Heating(Context context, double targetTemp) : base(
+      public Heating(IContext context, double targetTemp) : base(
         context, targetTemp
       ) {
         var tempSensor = context.Get<ITemperatureSensor>();

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/LightSwitch.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/LightSwitch.cs
@@ -2,19 +2,19 @@ namespace Chickensoft.LogicBlocks.Generator.Tests;
 
 [StateMachine]
 public class LightSwitch : LogicBlock<LightSwitch.Input, LightSwitch.State, LightSwitch.Output> {
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.Off(context);
 
   public abstract record Input {
     public record Toggle : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context) {
-    public record On(Context Context) : State(Context), IGet<Input.Toggle> {
+  public abstract record State(IContext Context) : StateLogic(Context) {
+    public record On(IContext Context) : State(Context), IGet<Input.Toggle> {
       State IGet<Input.Toggle>.On(Input.Toggle input) => new Off(Context);
     }
 
-    public record Off(Context Context) : State(Context), IGet<Input.Toggle> {
+    public record Off(IContext Context) : State(Context), IGet<Input.Toggle> {
       State IGet<Input.Toggle>.On(Input.Toggle input) => new On(Context);
     }
   }

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/Patterns.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/Patterns.cs
@@ -4,14 +4,14 @@ namespace Chickensoft.LogicBlocks.Generator.Tests;
 public class Patterns : LogicBlock<Patterns.Input, Patterns.State, LightSwitch.Output> {
   public enum Mode { One, Two, Three }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.One(context);
 
   public abstract record Input {
     public record SetMode(Mode Mode) : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context), IGet<Input.SetMode> {
+  public abstract record State(IContext Context) : StateLogic(Context), IGet<Input.SetMode> {
     public State On(Input.SetMode input) => input.Mode switch {
       Mode.One => new One(Context),
       Mode.Two => new Two(Context),
@@ -21,9 +21,9 @@ public class Patterns : LogicBlock<Patterns.Input, Patterns.State, LightSwitch.O
       },
       _ => throw new NotImplementedException()
     };
-    public record One(Context Context) : State(Context);
-    public record Two(Context Context) : State(Context);
-    public record Three(Context Context) : State(Context);
+    public record One(IContext Context) : State(Context);
+    public record Two(IContext Context) : State(Context);
+    public record Three(IContext Context) : State(Context);
   }
 
   public abstract record Output { }

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/SingleState.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/SingleState.cs
@@ -3,13 +3,13 @@ namespace Chickensoft.LogicBlocks.Generator.Tests;
 [StateMachine]
 public class SingleState :
   LogicBlock<SingleState.Input, SingleState.State, SingleState.Output> {
-  public override State GetInitialState(Context context) => new(Context);
+  public override State GetInitialState(IContext context) => new(Context);
 
   public abstract record Input {
     public record MyInput : Input { }
   }
   public record State : StateLogic, IGet<Input.MyInput> {
-    public State(Context context) : base(context) {
+    public State(IContext context) : base(context) {
       OnEnter<State>((previous) => Context.Output(new Output.MyOutput()));
       OnExit<State>((next) => Context.Output(new Output.MyOutput()));
     }

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/ToasterOven.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/ToasterOven.cs
@@ -2,7 +2,7 @@ namespace Chickensoft.LogicBlocks.Generator.Tests;
 [StateMachine]
 public class ToasterOven :
   LogicBlock<ToasterOven.Input, ToasterOven.State, ToasterOven.Output> {
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.Toasting(context, 0);
 
   public record Input {
@@ -12,9 +12,9 @@ public class ToasterOven :
     public record StartToasting(int ToastColor) : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context) {
+  public abstract record State(IContext Context) : StateLogic(Context) {
     public record Heating : State, IGet<Input.OpenDoor> {
-      public Heating(Context context) : base(context) {
+      public Heating(IContext context) : base(context) {
         OnEnter<Heating>(
           (previous) => Context.Output(new Output.TurnHeaterOn())
         );
@@ -29,7 +29,7 @@ public class ToasterOven :
     public record Toasting : Heating, IGet<Input.StartBaking> {
       public int ToastColor { get; }
 
-      public Toasting(Context context, int toastColor) : base(context) {
+      public Toasting(IContext context, int toastColor) : base(context) {
         ToastColor = toastColor;
 
         OnEnter<Toasting>(
@@ -48,7 +48,7 @@ public class ToasterOven :
     public record Baking : Heating, IGet<Input.StartToasting> {
       public int Temperature { get; }
 
-      public Baking(Context context, int temperature) : base(context) {
+      public Baking(IContext context, int temperature) : base(context) {
         Temperature = temperature;
 
         OnEnter<Baking>(
@@ -65,7 +65,7 @@ public class ToasterOven :
     }
 
     public record DoorOpen : State, IGet<Input.CloseDoor> {
-      public DoorOpen(Context context) : base(context) {
+      public DoorOpen(IContext context) : base(context) {
         OnEnter<DoorOpen>(
           (previous) => Context.Output(new Output.TurnLampOn())
         );

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/partial_split_across_files/PartialLogic1.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/partial_split_across_files/PartialLogic1.cs
@@ -5,13 +5,13 @@ using System;
 [StateMachine]
 public partial class PartialLogic :
   LogicBlock<PartialLogic.Input, PartialLogic.State, PartialLogic.Output> {
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     throw new NotImplementedException();
 
   public abstract record Input {
     public record One : Input;
   }
-  public abstract partial record State(Context Context) : StateLogic(Context);
+  public abstract partial record State(IContext Context) : StateLogic(Context);
   public abstract record Output {
     public record OutputA : Output;
     public record OutputEnterA : Output;

--- a/Chickensoft.LogicBlocks.Generator.Tests/test_cases/partial_split_across_files/PartialLogic2.cs
+++ b/Chickensoft.LogicBlocks.Generator.Tests/test_cases/partial_split_across_files/PartialLogic2.cs
@@ -4,7 +4,7 @@ public partial class PartialLogic :
   LogicBlock<PartialLogic.Input, PartialLogic.State, PartialLogic.Output> {
   public abstract partial record State : StateLogic {
     public partial record A : State, IGet<Input.One> {
-      public A(Context context) : base(context) {
+      public A(IContext context) : base(context) {
         OnEnter<A>(
           (previous) => Context.Output(new Output.OutputEnterA())
         );
@@ -14,6 +14,6 @@ public partial class PartialLogic :
       }
     }
 
-    public record B(Context Context) : State(Context);
+    public record B(IContext Context) : State(Context);
   }
 }

--- a/Chickensoft.LogicBlocks.Generator/Chickensoft.LogicBlocks.Generator.csproj
+++ b/Chickensoft.LogicBlocks.Generator/Chickensoft.LogicBlocks.Generator.csproj
@@ -11,7 +11,7 @@
     <NoWarn>NU5128</NoWarn>
 
     <Title>LogicBlocks Generator</Title>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Description></Description>
     <Copyright>© 2023 Chickensoft Games</Copyright>
     <Authors>Chickensoft</Authors>

--- a/Chickensoft.LogicBlocks.Generator/src/common/utils/Constants.cs
+++ b/Chickensoft.LogicBlocks.Generator/src/common/utils/Constants.cs
@@ -8,7 +8,7 @@ public class Constants {
   public static int SPACES_PER_INDENT = 2;
 
   public const string LOGIC_BLOCK_GET_INITIAL_STATE = "GetInitialState";
-  public const string LOGIC_BLOCK_CONTEXT_ID = "global::Chickensoft.LogicBlocks.Logic.Context";
+  public const string LOGIC_BLOCK_CONTEXT_ID = "global::Chickensoft.LogicBlocks.Logic.IContext";
   public const string LOGIC_BLOCK_CONTEXT_OUTPUT = "Output";
   public const string LOGIC_BLOCK_STATE_LOGIC_ON_ENTER = "OnEnter";
   public const string LOGIC_BLOCK_STATE_LOGIC_ON_EXIT = "OnExit";

--- a/Chickensoft.LogicBlocks.Tests/Chickensoft.LogicBlocks.Tests.csproj
+++ b/Chickensoft.LogicBlocks.Tests/Chickensoft.LogicBlocks.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/FakeLogicBlock.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/FakeLogicBlock.cs
@@ -17,12 +17,12 @@ public partial class FakeLogicBlock {
     public record SelfInput(Input Input) : Input;
     public record InputCallback(
       Action Callback,
-      Func<Context, State> Next
+      Func<IContext, State> Next
     ) : Input;
-    public record Custom(Func<Context, State> Next) : Input;
+    public record Custom(Func<IContext, State> Next) : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context),
+  public abstract record State(IContext Context) : StateLogic(Context),
     IGet<Input.InputOne>,
     IGet<Input.InputTwo>,
     IGet<Input.InputThree>,
@@ -67,26 +67,26 @@ public partial class FakeLogicBlock {
 
     public State On(Input.SelfInput input) => Context.Input(input.Input);
 
-    public record StateA(Context Context, int Value1, int Value2) :
+    public record StateA(IContext Context, int Value1, int Value2) :
       State(Context);
-    public record StateB(Context Context, string Value1, string Value2) :
+    public record StateB(IContext Context, string Value1, string Value2) :
       State(Context);
-    public record StateC(Context Context, string Value) :
+    public record StateC(IContext Context, string Value) :
       State(Context);
-    public record StateD(Context Context, string Value1, string Value2) :
+    public record StateD(IContext Context, string Value1, string Value2) :
       State(Context);
 
-    public record NothingState(Context Context) : State(Context);
+    public record NothingState(IContext Context) : State(Context);
 
     public record Custom : State {
-      public Custom(Context context, Action<Context> setupCallback) :
+      public Custom(IContext context, Action<IContext> setupCallback) :
         base(context) {
         setupCallback(context);
       }
     }
 
     public record OnEnterState : State {
-      public OnEnterState(Context context, Action<State> onEnter) :
+      public OnEnterState(IContext context, Action<State> onEnter) :
         base(context) {
         OnEnter<OnEnterState>(onEnter);
       }
@@ -103,13 +103,13 @@ public partial class FakeLogicBlock
   : LogicBlock<
     FakeLogicBlock.Input, FakeLogicBlock.State, FakeLogicBlock.Output
   > {
-  public Func<Context, State>? InitialState { get; init; }
+  public Func<IContext, State>? InitialState { get; init; }
 
   public List<Exception> Exceptions { get; } = new();
 
   public void PublicSet<T>(T value) where T : notnull => Set(value);
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     InitialState?.Invoke(context) ?? new State.StateA(context, 1, 2);
 
   private readonly Action<Exception>? _onError;

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/FakeLogicBlockAsync.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/FakeLogicBlockAsync.cs
@@ -15,12 +15,12 @@ public partial class FakeLogicBlockAsync {
     public record SelfInput(Input Input) : Input;
     public record InputCallback(
       Action Callback,
-      Func<Context, State> Next
+      Func<IContext, State> Next
     ) : Input;
-    public record Custom(Func<Context, State> Next) : Input;
+    public record Custom(Func<IContext, State> Next) : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context),
+  public abstract record State(IContext Context) : StateLogic(Context),
     IGet<Input.InputOne>,
     IGet<Input.InputTwo>,
     IGet<Input.InputThree>,
@@ -70,23 +70,23 @@ public partial class FakeLogicBlockAsync {
       return this;
     }
 
-    public record StateA(Context Context, int Value1, int Value2) :
+    public record StateA(IContext Context, int Value1, int Value2) :
       State(Context);
-    public record StateB(Context Context, string Value1, string Value2) :
+    public record StateB(IContext Context, string Value1, string Value2) :
       State(Context);
-    public record StateC(Context Context, string Value) :
+    public record StateC(IContext Context, string Value) :
       State(Context);
-    public record StateD(Context Context, string Value1, string Value2) :
+    public record StateD(IContext Context, string Value1, string Value2) :
       State(Context);
     public record Custom : State {
-      public Custom(Context context, Action<Context> setupCallback) :
+      public Custom(IContext context, Action<IContext> setupCallback) :
         base(context) {
         setupCallback(context);
       }
     }
 
     public record OnEnterState : State {
-      public OnEnterState(Context context, Func<State, Task> onEnter) :
+      public OnEnterState(IContext context, Func<State, Task> onEnter) :
         base(context) {
         OnEnter<OnEnterState>(onEnter);
       }
@@ -103,11 +103,11 @@ public partial class FakeLogicBlockAsync
   : LogicBlockAsync<
     FakeLogicBlockAsync.Input, FakeLogicBlockAsync.State, FakeLogicBlockAsync.Output
   > {
-  public Func<Context, State>? InitialState { get; init; }
+  public Func<IContext, State>? InitialState { get; init; }
 
   public List<Exception> Exceptions { get; } = new();
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     InitialState?.Invoke(context) ?? new State.StateA(context, 1, 2);
 
   private readonly Action<Exception>? _onError;

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/MyLogicBlock.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/MyLogicBlock.cs
@@ -1,0 +1,38 @@
+namespace Chickensoft.LogicBlocks.Tests.Fixtures;
+
+using Chickensoft.LogicBlocks.Generator;
+
+[StateMachine]
+public partial class MyLogicBlock :
+  LogicBlock<MyLogicBlock.Input, MyLogicBlock.State, MyLogicBlock.Output> {
+  public override State GetInitialState(IContext context) =>
+    new State.SomeState(context);
+
+  public abstract record Input {
+    public record SomeInput : Input;
+    public record SomeOtherInput : Input;
+  }
+
+  public abstract record State(IContext Context) : StateLogic(Context) {
+    public record SomeState(IContext Context) : State(Context),
+      IGet<Input.SomeInput> {
+      public State On(Input.SomeInput input) {
+        Context.Output(new Output.SomeOutput());
+        return new SomeOtherState(Context);
+      }
+    }
+
+    public record SomeOtherState(IContext Context) : State(Context),
+      IGet<Input.SomeOtherInput> {
+      public State On(Input.SomeOtherInput input) {
+        Context.Output(new Output.SomeOtherOutput());
+        return new SomeState(Context);
+      }
+    }
+  }
+
+  public abstract record Output {
+    public record SomeOutput : Output;
+    public record SomeOtherOutput : Output;
+  }
+}

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/MyLogicBlock.g.puml
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/MyLogicBlock.g.puml
@@ -1,0 +1,11 @@
+@startuml MyLogicBlock
+state "MyLogicBlock State" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State {
+  state "SomeState" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState
+  state "SomeOtherState" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeOtherState
+}
+
+Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeOtherState --> Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState : SomeOtherInput
+Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState --> Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeOtherState : SomeInput
+
+[*] --> Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState
+@enduml

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/MyObject.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/MyObject.cs
@@ -1,0 +1,13 @@
+namespace Chickensoft.LogicBlocks.Tests.Fixtures;
+
+public class MyObject {
+  public MyLogicBlock Logic { get; }
+
+  public MyObject(MyLogicBlock logic) {
+    Logic = logic;
+  }
+
+  // Method we want to test
+  public MyLogicBlock.State DoSomething() =>
+    Logic.Input(new MyLogicBlock.Input.SomeInput());
+}

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/NonEquatable.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/NonEquatable.cs
@@ -8,17 +8,17 @@ public class NonEquatable :
 
   public abstract class State : IStateLogic,
     IGet<Input.GoToA>, IGet<Input.GoToB> {
-    public Context Context { get; }
-    public State(Context context) {
+    public IContext Context { get; }
+    public State(IContext context) {
       Context = context;
     }
 
     public class A : State {
-      public A(Context context) : base(context) { }
+      public A(IContext context) : base(context) { }
     }
 
     public class B : State {
-      public B(Context context) : base(context) { }
+      public B(IContext context) : base(context) { }
     }
 
     public State On(Input.GoToA input) => new A(Context);
@@ -27,6 +27,6 @@ public class NonEquatable :
 
   public class Output { }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.A(context);
 }

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachine.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachine.cs
@@ -15,7 +15,7 @@ public partial class TestMachine :
     public record Deactivate() : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context),
+  public abstract record State(IContext Context) : StateLogic(Context),
     IGet<Input.Activate> {
     public State On(Input.Activate input) =>
       input.Secondary switch {
@@ -25,7 +25,7 @@ public partial class TestMachine :
       };
 
     public abstract record Activated : State, IGet<Input.Deactivate> {
-      public Activated(Context context) : base(context) {
+      public Activated(IContext context) : base(context) {
         OnEnter<Activated>(
           (previous) => context.Output(new Output.Activated())
         );
@@ -37,7 +37,7 @@ public partial class TestMachine :
       public State On(Input.Deactivate input) => new Deactivated(Context);
 
       public record Blooped : Activated {
-        public Blooped(Context context) : base(context) {
+        public Blooped(IContext context) : base(context) {
           OnEnter<Blooped>(
             (previous) => context.Output(new Output.Blooped())
           );
@@ -48,7 +48,7 @@ public partial class TestMachine :
       }
 
       public record Bopped : Activated {
-        public Bopped(Context context) : base(context) {
+        public Bopped(IContext context) : base(context) {
           OnEnter<Bopped>(
             (previous) => context.Output(new Output.Bopped())
           );
@@ -60,7 +60,7 @@ public partial class TestMachine :
     }
 
     public record Deactivated : State {
-      public Deactivated(Context context) : base(context) {
+      public Deactivated(IContext context) : base(context) {
         OnEnter<Deactivated>(
           (previous) => context.Output(new Output.Deactivated())
         );
@@ -82,6 +82,6 @@ public partial class TestMachine :
     public record BoppedCleanUp() : Output;
   }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.Deactivated(context);
 }

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachineAsync.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachineAsync.cs
@@ -9,7 +9,7 @@ public partial class TestMachineAsync :
     public record Deactivate() : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context),
+  public abstract record State(IContext Context) : StateLogic(Context),
     IGet<Input.Activate> {
     public async Task<State> On(Input.Activate input) {
       await Task.Delay(5);
@@ -22,7 +22,7 @@ public partial class TestMachineAsync :
     }
 
     public abstract record Activated : State, IGet<Input.Deactivate> {
-      public Activated(Context context) : base(context) {
+      public Activated(IContext context) : base(context) {
         OnEnter<Activated>(
           async (previous) => {
             await Task.Delay(10);
@@ -41,7 +41,7 @@ public partial class TestMachineAsync :
         new Deactivated(Context);
 
       public record Blooped : Activated {
-        public Blooped(Context context) : base(context) {
+        public Blooped(IContext context) : base(context) {
           OnEnter<Blooped>(
             async (previous) => {
               await Task.Delay(10);
@@ -58,7 +58,7 @@ public partial class TestMachineAsync :
       }
 
       public record Bopped : Activated {
-        public Bopped(Context context) : base(context) {
+        public Bopped(IContext context) : base(context) {
           OnEnter<Bopped>(
             async (previous) => {
               await Task.Delay(10);
@@ -76,7 +76,7 @@ public partial class TestMachineAsync :
     }
 
     public record Deactivated : State {
-      public Deactivated(Context context) : base(context) {
+      public Deactivated(IContext context) : base(context) {
         OnEnter<Deactivated>(
           async (previous) => {
             await Task.Delay(20);
@@ -104,7 +104,7 @@ public partial class TestMachineAsync :
     public record BoppedCleanUp() : Output;
   }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     new State.Deactivated(context);
 }
 

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachineReusable.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachineReusable.cs
@@ -14,7 +14,7 @@ public partial class TestMachineReusable :
     public record Deactivate() : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context),
+  public abstract record State(IContext Context) : StateLogic(Context),
     IGet<Input.Activate> {
     public State On(Input.Activate input) =>
       input.Secondary switch {
@@ -24,7 +24,7 @@ public partial class TestMachineReusable :
       };
 
     public abstract record Activated : State, IGet<Input.Deactivate> {
-      public Activated(Context context) : base(context) {
+      public Activated(IContext context) : base(context) {
         OnEnter<Activated>(
           (previous) => context.Output(new Output.Activated())
         );
@@ -36,7 +36,7 @@ public partial class TestMachineReusable :
       public State On(Input.Deactivate input) => Context.Get<Deactivated>();
 
       public record Blooped : Activated {
-        public Blooped(Context context) : base(context) {
+        public Blooped(IContext context) : base(context) {
           OnEnter<Blooped>(
             (previous) => context.Output(new Output.Blooped())
           );
@@ -47,7 +47,7 @@ public partial class TestMachineReusable :
       }
 
       public record Bopped : Activated {
-        public Bopped(Context context) : base(context) {
+        public Bopped(IContext context) : base(context) {
           OnEnter<Bopped>(
             (previous) => context.Output(new Output.Bopped())
           );
@@ -59,7 +59,7 @@ public partial class TestMachineReusable :
     }
 
     public record Deactivated : State {
-      public Deactivated(Context context) : base(context) {
+      public Deactivated(IContext context) : base(context) {
         OnEnter<Deactivated>(
           (previous) => context.Output(new Output.Deactivated())
         );
@@ -87,6 +87,6 @@ public partial class TestMachineReusable :
     Set(new State.Deactivated(Context));
   }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     context.Get<State.Deactivated>();
 }

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachineReusableAsync.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/TestMachineReusableAsync.cs
@@ -15,7 +15,7 @@ public partial class TestMachineReusableAsync :
     public record Deactivate() : Input;
   }
 
-  public abstract record State(Context Context) : StateLogic(Context),
+  public abstract record State(IContext Context) : StateLogic(Context),
     IGet<Input.Activate> {
     public async Task<State> On(Input.Activate input) {
       await Task.Delay(5);
@@ -28,7 +28,7 @@ public partial class TestMachineReusableAsync :
     }
 
     public abstract record Activated : State, IGet<Input.Deactivate> {
-      public Activated(Context context) : base(context) {
+      public Activated(IContext context) : base(context) {
         OnEnter<Activated>(
           async (previous) => {
             await Task.Delay(10);
@@ -47,7 +47,7 @@ public partial class TestMachineReusableAsync :
         Context.Get<Deactivated>();
 
       public record Blooped : Activated {
-        public Blooped(Context context) : base(context) {
+        public Blooped(IContext context) : base(context) {
           OnEnter<Blooped>(
             async (previous) => {
               await Task.Delay(10);
@@ -64,7 +64,7 @@ public partial class TestMachineReusableAsync :
       }
 
       public record Bopped : Activated {
-        public Bopped(Context context) : base(context) {
+        public Bopped(IContext context) : base(context) {
           OnEnter<Bopped>(
             async (previous) => {
               await Task.Delay(10);
@@ -82,7 +82,7 @@ public partial class TestMachineReusableAsync :
     }
 
     public record Deactivated : State {
-      public Deactivated(Context context) : base(context) {
+      public Deactivated(IContext context) : base(context) {
         OnEnter<Deactivated>(
           async (previous) => {
             await Task.Delay(20);
@@ -116,7 +116,7 @@ public partial class TestMachineReusableAsync :
     Set(new State.Deactivated(Context));
   }
 
-  public override State GetInitialState(Context context) =>
+  public override State GetInitialState(IContext context) =>
     context.Get<State.Deactivated>();
 }
 

--- a/Chickensoft.LogicBlocks.Tests/test/src/ExampleTest.g.puml
+++ b/Chickensoft.LogicBlocks.Tests/test/src/ExampleTest.g.puml
@@ -1,0 +1,3 @@
+@startuml MyLogicBlock
+state "MyLogicBlock State" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State
+@enduml

--- a/Chickensoft.LogicBlocks.Tests/test/src/LogicBlock.BindingTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/LogicBlock.BindingTest.cs
@@ -2,6 +2,7 @@ namespace Chickensoft.LogicBlocks.Tests;
 
 using Chickensoft.LogicBlocks.Tests.Fixtures;
 using Chickensoft.LogicBlocks.Tests.TestUtils;
+using Moq;
 using Shouldly;
 using Xunit;
 
@@ -240,6 +241,27 @@ public class BlocGlueTests {
     block.Input(new FakeLogicBlock.Input.InputError());
 
     called.ShouldBeTrue();
+  }
+
+  [Fact]
+  public void CanBeMocked() {
+    var logic = new Mock<
+      ILogicBlock<
+        FakeLogicBlock.Input, FakeLogicBlock.State, FakeLogicBlock.Output
+      >
+    >();
+
+    var binding = new Mock<FakeLogicBlock.IBinding>();
+    var context = new Mock<FakeLogicBlock.IContext>();
+
+    var input = new FakeLogicBlock.Input.InputOne(1, 2);
+    var state = new FakeLogicBlock.State.StateA(context.Object, 1, 2);
+
+    logic.Setup(logic => logic.Bind()).Returns(binding.Object);
+    logic.Setup(logic => logic.Input(input)).Returns(state);
+
+    logic.Object.Bind().ShouldBe(binding.Object);
+    logic.Object.Input(input).ShouldBe(state);
   }
 
   [Fact]

--- a/Chickensoft.LogicBlocks.Tests/test/src/examples/MyLogicBlock.SomeStateTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/examples/MyLogicBlock.SomeStateTest.cs
@@ -1,0 +1,28 @@
+namespace Chickensoft.LogicBlocks.Tests.Examples;
+
+using Chickensoft.LogicBlocks.Tests.Fixtures;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class SomeStateTest {
+  [Fact]
+  public void HandlesSomeInput() {
+    var context = new Mock<MyLogicBlock.IContext>();
+    var state = new MyLogicBlock.State.SomeState(context.Object);
+
+    // Expect our state to output SomeOutput when SomeInput is received.
+    context
+      .Setup(context => context.Output(new MyLogicBlock.Output.SomeOutput()));
+
+    // Perform the action we are testing on our state.
+    var result = state.On(new MyLogicBlock.Input.SomeInput());
+
+    // Make sure the output we expected was produced by ensuring our mock
+    // context was called the same way we set it up.
+    context.VerifyAll();
+
+    // Make sure we got the next state.
+    result.ShouldBeOfType<MyLogicBlock.State.SomeOtherState>();
+  }
+}

--- a/Chickensoft.LogicBlocks.Tests/test/src/examples/MyObjectTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/examples/MyObjectTest.cs
@@ -1,0 +1,37 @@
+namespace Chickensoft.LogicBlocks.Tests.Examples;
+
+using Chickensoft.LogicBlocks.Tests.Fixtures;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class MyObjectTest {
+  [Fact]
+  public void DoSomethingDoesSomething() {
+    // Our unit test follows the AAA pattern: Arrange, Act, Assert.
+    // Or Setup, Execute, and Verify, if you prefer. Etc.
+
+    // Setup
+    var logic = new Mock<MyLogicBlock>();
+    var context = new Mock<MyLogicBlock.IContext>();
+
+    var myObject = new MyObject(logic.Object);
+
+    // Create a state that we expect to be returned.
+    var expectedState = new MyLogicBlock.State.SomeState(context.Object);
+
+    // Setup the mock of the logic block to return our expected state whenever
+    // it receives the input SomeInput.
+    logic.Setup(logic => logic.Input(It.IsAny<MyLogicBlock.Input.SomeInput>()))
+      .Returns(expectedState);
+
+    // Execute the method we want to test.
+    var result = myObject.DoSomething();
+
+    // Verify that method returned the correct value.
+    result.ShouldBe(expectedState);
+
+    // Verify that the method invoked our logic block as expected.
+    logic.VerifyAll();
+  }
+}

--- a/Chickensoft.LogicBlocks/src/Logic.Context.cs
+++ b/Chickensoft.LogicBlocks/src/Logic.Context.cs
@@ -6,21 +6,7 @@ public abstract partial class Logic<
   TInput, TState, TOutput, THandler, TInputReturn, TUpdate
 > {
   /// <summary>Logic block context provided to each logic block state.</summary>
-  public readonly record struct Context {
-    private Logic<
-      TInput, TState, TOutput, THandler, TInputReturn, TUpdate
-    > Logic { get; }
-
-    /// <summary>
-    /// Creates a new logic block context for the given logic block.
-    /// </summary>
-    /// <param name="logic">Logic block.</param>
-    public Context(Logic<
-      TInput, TState, TOutput, THandler, TInputReturn, TUpdate
-    > logic) {
-      Logic = logic;
-    }
-
+  public interface IContext {
     /// <summary>
     /// Adds an input value to the logic block's internal input queue and
     /// returns the current state.
@@ -35,31 +21,57 @@ public abstract partial class Logic<
     /// <param name="input">Input to process.</param>
     /// <typeparam name="TInputType">Type of the input.</typeparam>
     /// <returns>Logic block input return value.</returns>
+    TState Input<TInputType>(TInputType input) where TInputType : TInput;
+    /// <summary>
+    /// Produces a logic block output value.
+    /// </summary>
+    /// <param name="output">Output value.</param>
+    void Output(TOutput output);
+    /// <summary>
+    /// Gets a value from the logic block's blackboard.
+    /// </summary>
+    /// <typeparam name="TDataType">Type of value to retrieve.</typeparam>
+    /// <returns>The requested value.</returns>
+    TDataType Get<TDataType>() where TDataType : notnull;
+    /// <summary>
+    /// Adds an error to a logic block. Errors are immediately processed by the
+    /// logic block's <see cref="HandleError(Exception)"/> callback.
+    /// </summary>
+    /// <param name="e">Exception to add.</param>
+    void AddError(Exception e);
+  }
+
+  /// <summary>Logic block context provided to each logic block state.</summary>
+  internal readonly record struct Context : IContext {
+    private Logic<
+      TInput, TState, TOutput, THandler, TInputReturn, TUpdate
+    > Logic { get; }
+
+    /// <summary>
+    /// Creates a new logic block context for the given logic block.
+    /// </summary>
+    /// <param name="logic">Logic block.</param>
+    public Context(Logic<
+      TInput, TState, TOutput, THandler, TInputReturn, TUpdate
+    > logic) {
+      Logic = logic;
+    }
+
+    /// <inheritdoc />
     public TState Input<TInputType>(TInputType input)
       where TInputType : TInput {
       Logic.Input(input);
       return Logic.Value;
     }
 
-    /// <summary>
-    /// Produces a logic block output value.
-    /// </summary>
-    /// <param name="output">Output value.</param>
+    /// <inheritdoc />
     public void Output(TOutput output) => Logic.OutputValue(output);
 
-    /// <summary>
-    /// Gets a value from the logic block's blackboard.
-    /// </summary>
-    /// <typeparam name="TDataType">Type of value to retrieve.</typeparam>
-    /// <returns>The requested value.</returns>
+    /// <inheritdoc />
     public TDataType Get<TDataType>() where TDataType : notnull =>
       Logic.Get<TDataType>();
 
-    /// <summary>
-    /// Adds an error to a logic block. Errors are immediately processed by the
-    /// logic block's <see cref="HandleError(Exception)"/> callback.
-    /// </summary>
-    /// <param name="e">Exception to add.</param>
+    /// <inheritdoc />
     public void AddError(Exception e) => Logic.AddError(e);
   }
 }

--- a/Chickensoft.LogicBlocks/src/Logic.StateLogic.cs
+++ b/Chickensoft.LogicBlocks/src/Logic.StateLogic.cs
@@ -12,7 +12,7 @@ public abstract partial class Logic<
   /// </summary>
   public interface IStateLogic {
     /// <summary>Logic block context.</summary>
-    Context Context { get; }
+    IContext Context { get; }
   }
 
   internal class StateLogicState {
@@ -46,7 +46,7 @@ public abstract partial class Logic<
   /// </summary>
   public abstract record StateLogic : IStateLogic {
     /// <summary>Logic block context.</summary>
-    public Context Context { get; }
+    public IContext Context { get; }
 
     internal StateLogicState InternalState { get; }
 
@@ -54,7 +54,7 @@ public abstract partial class Logic<
     /// Creates a new instance of the logic block base state record.
     /// </summary>
     /// <param name="context">Logic block context.</param>
-    public StateLogic(Context context) {
+    public StateLogic(IContext context) {
       Context = context;
       InternalState = new();
     }


### PR DESCRIPTION
- Extracts interfaces from core logic block components to enable logic blocks to be unit-tested.
- Updates documentation to demonstrate how to write unit tests for logic blocks.
- Updates API usage: instead of passing `Context` around, you must use `IContext` instead.
- Adds production unit test examples to the test suite.