### PR TITLE
fix: inputs added on first attach will be queued correctly now

### DIFF
--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/GreedyLogic.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/GreedyLogic.cs
@@ -1,0 +1,27 @@
+namespace Chickensoft.LogicBlocks.Tests.Fixtures;
+
+public class GreedyLogic : LogicBlock<GreedyLogic.State> {
+  public override State GetInitialState() => new State.A();
+
+  public static class Input {
+    public readonly record struct GoToB;
+    public readonly record struct GoToC;
+  }
+
+  public abstract partial record State : StateLogic {
+    public record A : State, IGet<Input.GoToB>, IGet<Input.GoToC> {
+      public A() {
+        OnAttach(() => {
+          Context.Input(new Input.GoToB());
+          Context.Input(new Input.GoToC());
+        });
+      }
+
+      public State On(Input.GoToB input) => new B();
+      public State On(Input.GoToC input) => new C();
+    }
+
+    public record B : State { }
+    public record C : State { }
+  }
+}

--- a/Chickensoft.LogicBlocks.Tests/test/src/AttachTests.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/AttachTests.cs
@@ -1,0 +1,14 @@
+namespace Chickensoft.LogicBlocks.Tests;
+
+using Chickensoft.LogicBlocks.Tests.Fixtures;
+using Shouldly;
+using Xunit;
+
+public class AttachTests {
+  [Fact]
+  public void MultipleInputsOnAttachAreQueued() {
+    var logic = new GreedyLogic();
+
+    Should.NotThrow(() => logic.Start());
+  }
+}

--- a/Chickensoft.LogicBlocks/src/Logic.cs
+++ b/Chickensoft.LogicBlocks/src/Logic.cs
@@ -144,16 +144,7 @@ public abstract partial class Logic<
   public IContext Context { get; }
 
   /// <inheritdoc />
-  public TState Value {
-    get {
-      if (_value is null) {
-        _value = GetInitialState();
-        _value.Attach(Context);
-      }
-
-      return _value;
-    }
-  }
+  public abstract TState Value { get; }
 
   /// <inheritdoc />
   public abstract bool IsProcessing { get; }

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -61,7 +61,23 @@ Logic<
   /// <inheritdoc />
   public abstract override TState GetInitialState();
 
+  /// <inheritdoc />
+  public override TState Value => _value ?? AttachState();
+
+  private TState AttachState() {
+    _isProcessing = true;
+    _value = GetInitialState();
+    _value.Attach(Context);
+    _isProcessing = false;
+    return Process();
+  }
+
   internal override TState Process() {
+    if (_value is null) {
+      // No state yet.
+      return AttachState(); // Calls Process() again.
+    }
+
     if (IsProcessing) {
       return Value;
     }

--- a/Chickensoft.LogicBlocks/src/LogicBlockAsync.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlockAsync.cs
@@ -73,7 +73,28 @@ ILogicBlockAsync<
   /// <inheritdoc />
   public abstract override TState GetInitialState();
 
+  /// <inheritdoc />
+  public override TState Value => _value ?? AttachState();
+
+  private TState AttachState() {
+    _value = GetInitialState();
+    _value.Attach(Context);
+
+    // If inputs were added to the logic block during the attach callbacks,
+    // this will kickstart the asynchronous process of handling them. Otherwise,
+    // nothing happens.
+    Process();
+
+    // Return the current state, regardless if it's about to change.
+    return _value;
+  }
+
   internal override Task<TState> Process() {
+    if (_value is null) {
+      // No state yet.
+      AttachState();
+    }
+
     if (IsProcessing) {
       return _processTask.Task;
     }


### PR DESCRIPTION
Fixes a minor oversight from the previous big chance: inputs added during initial state loading from the attach callbacks will queue, rather than processing instantly like they were.