### PR TITLE
fix: prevent outputs from getting boxed and hitting the heap unnecessarily

### DIFF
--- a/Chickensoft.LogicBlocks.Tests/test/src/LogicBlockTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/LogicBlockTest.cs
@@ -370,7 +370,7 @@ public class LogicBlockTest {
   [Fact]
   public void CreatesFakeContext() {
     var inputs = new List<object> { "a", 2, true };
-    var outputs = new List<object> { "b", 3, false };
+    var outputs = new List<int> { 1, 2 };
     var errors = new List<Exception> {
       new InvalidOperationException(),
       new InvalidCastException()
@@ -391,7 +391,7 @@ public class LogicBlockTest {
     errors.ForEach((e) => context.AddError(e));
 
     context.Inputs.ShouldBe(inputs);
-    context.Outputs.ShouldBe(outputs);
+    context.Outputs.ShouldBe(outputs.Select(static t => t as object));
     context.Errors.ShouldBe(errors);
 
     context.Get<string>().ShouldBe("c");

--- a/Chickensoft.LogicBlocks/src/IContext.cs
+++ b/Chickensoft.LogicBlocks/src/IContext.cs
@@ -24,7 +24,7 @@ public interface IContext {
   /// Produces a logic block output value.
   /// </summary>
   /// <param name="output">Output value.</param>
-  void Output(in object output);
+  void Output<T>(in T output) where T : struct;
 
   /// <summary>
   /// Gets a value from the logic block's blackboard.

--- a/Chickensoft.LogicBlocks/src/Logic.Context.cs
+++ b/Chickensoft.LogicBlocks/src/Logic.Context.cs
@@ -22,7 +22,8 @@ public abstract partial class Logic<TState, THandler, TInputReturn, TUpdate> {
       where TInputType : notnull => Logic.Input(input);
 
     /// <inheritdoc />
-    public void Output(in object output) => Logic.OutputValue(in output);
+    public void Output<T>(in T output) where T : struct =>
+      Logic.OutputValue(output);
 
     /// <inheritdoc />
     public TDataType Get<TDataType>() where TDataType : notnull =>
@@ -57,8 +58,8 @@ public abstract partial class Logic<TState, THandler, TInputReturn, TUpdate> {
     }
 
     /// <inheritdoc />
-    public void Output(in object output) {
-      if (Context is not IContext context) {
+    public void Output<T>(in T output) where T : struct {
+      if (Context is not { } context) {
         throw new InvalidOperationException(
           "Cannot add output to a logic block with an uninitialized context."
         );

--- a/Chickensoft.LogicBlocks/src/Logic.FakeContext.cs
+++ b/Chickensoft.LogicBlocks/src/Logic.FakeContext.cs
@@ -36,7 +36,8 @@ public abstract partial class Logic<TState, THandler, TInputReturn, TUpdate> {
     public void Input<TInputType>(TInputType input)
       where TInputType : notnull => _inputs.Add(input);
 
-    public void Output(in object output) => _outputs.Add(output);
+    public void Output<T>(in T output) where T : struct =>
+      _outputs.Add(output);
 
     public void AddError(Exception e) => _errors.Add(e);
 


### PR DESCRIPTION
Outputs were getting boxed when casted to `object`, so this prevents that. Now, unless you're using the FakeContext for testing, outputs will always just be passed through.

This does restrict outputs to being value types — but they should be anyways ;)