### PR TITLE
test: fix serialization tests on Windows

### DIFF
--- a/Chickensoft.LogicBlocks.Tests/test/src/LogicBlock.SerializationTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/LogicBlock.SerializationTest.cs
@@ -1,6 +1,7 @@
 namespace Chickensoft.LogicBlocks.Tests.Serialization;
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Chickensoft.Collections;
 using Chickensoft.Introspection;
 using Chickensoft.LogicBlocks.Tests.Fixtures;
@@ -31,10 +32,10 @@ public partial class LogicBlockSerializationTest {
 
     var options = CreateOptions();
 
-    var json = JsonSerializer.Serialize(logic, options);
+    var jsonText = JsonSerializer.Serialize(logic, options);
+    var jsonNode = JsonNode.Parse(jsonText);
 
-    json.ShouldBe(
-      /*lang=json,strict*/
+    var jsonExpectedText = /*lang=json,strict*/
       """
       {
         "$type": "serializable_logic_block",
@@ -60,8 +61,9 @@ public partial class LogicBlockSerializationTest {
           }
         }
       }
-      """
-    );
+      """;
+    var jsonExpectedNode = JsonNode.Parse(jsonExpectedText);
+    JsonNode.DeepEquals(jsonNode, jsonExpectedNode).ShouldBeTrue();
   }
 
   [Fact]

--- a/Chickensoft.LogicBlocks.Tutorial.Tests/SerializableLogicBlockTest.cs
+++ b/Chickensoft.LogicBlocks.Tutorial.Tests/SerializableLogicBlockTest.cs
@@ -1,6 +1,7 @@
 namespace Chickensoft.LogicBlocks.Tutorial.Tests;
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Chickensoft.Serialization;
 using Shouldly;
 using Xunit;
@@ -19,10 +20,10 @@ public class SerializableLogicBlockTest {
 
     var logic = new SerializableLogicBlock();
 
-    var json = JsonSerializer.Serialize(logic, options);
+    var jsonText = JsonSerializer.Serialize(logic, options);
+    var jsonNode = JsonNode.Parse(jsonText);
 
-    json.ShouldBe(
-      /*language=json*/
+    var jsonExpectedText = /*language=json*/
       """
       {
         "$type": "serializable_logic",
@@ -37,8 +38,10 @@ public class SerializableLogicBlockTest {
           "values": {}
         }
       }
-      """
-    );
+      """;
+    var jsonExpectedNode = JsonNode.Parse(jsonExpectedText);
+
+    JsonNode.DeepEquals(jsonNode, jsonExpectedNode).ShouldBeTrue();
   }
 
   [Fact]


### PR DESCRIPTION
Serialization tests (`Chickensoft.LogicBlocks.Tests.Serialization.LogicBlockSerialization.SerializesLogicBlock` and `Chickensoft.LogicBlocks.Tutorial.Tests.SerializableLogicBlockTests.Serializes`) fail on Windows:

![Screenshot 2024-06-20 133319](https://github.com/chickensoft-games/LogicBlocks/assets/23439518/8f6d827d-59b0-4e5c-ab54-5b96daca9586)

This is because the generated JSON has CRLF line endings on Windows, but the expected string literal has LF:

![Screenshot 2024-06-20 132351](https://github.com/chickensoft-games/LogicBlocks/assets/23439518/b3c521c8-ec7c-4a9f-8121-80e8400ced0b)

This change uses `JsonNode.DeepEquals()` to compare expected and generated JSON strings, avoiding whitespace issues generally, [as recommended in the proposal discussion for the forthcoming `JsonSerializerOptions.NewLine` property](https://github.com/dotnet/runtime/issues/84117#issuecomment-1959115235).