### PR TITLE
Fix compiler-version (and other) warnings

### DIFF
--- a/Chickensoft.GeneratorTester/Chickensoft.GeneratorTester.csproj
+++ b/Chickensoft.GeneratorTester/Chickensoft.GeneratorTester.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.24324.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Chickensoft.GeneratorTester/src/Tester.cs
+++ b/Chickensoft.GeneratorTester/src/Tester.cs
@@ -88,55 +88,6 @@ public static class Tester {
       .DescendantNodes()
       .First(node => node is T);
 
-  /// <summary>
-  /// Parses the given code and returns the first node of the given type within
-  /// the syntax tree and the semantic model for the code.
-  /// </summary>
-  /// <param name="code">Source code string.</param>
-  /// <param name="symbol">Symbol for the node found in the tree.</param>
-  /// <typeparam name="TNode">Type of the node to find in the tree.</typeparam>
-  /// <typeparam name="TSymbol">Type of symbol to find.</typeparam>
-  /// <returns>First matching node within the tree of type
-  /// <typeparamref name="TNode" />.</returns>
-  public static TNode Parse<TNode, TSymbol>(string code, out TSymbol symbol)
-    where TNode : SyntaxNode
-    where TSymbol : ISymbol {
-    var tree = CSharpSyntaxTree.ParseText(code);
-    var node = (TNode)tree
-      .GetRoot()
-      .DescendantNodes()
-      .First(node => node is TNode);
-
-    symbol = GetSymbol<TNode, TSymbol>(tree, node);
-
-    return node;
-  }
-
-  /// <summary>
-  /// Given a syntax tree and a node of a given type, returns the symbol for
-  /// that node.
-  /// </summary>
-  /// <param name="tree">Syntax tree.</param>
-  /// <param name="node">Syntax node within the tree.</param>
-  /// <typeparam name="TNode">Type of the syntax node given.</typeparam>
-  /// <typeparam name="TSymbol">Type of the symbol to get.</typeparam>
-  /// <returns>Symbol associated with the syntax tree node.</returns>
-  public static TSymbol GetSymbol<TNode, TSymbol>(SyntaxTree tree, TNode node)
-    where TNode : SyntaxNode
-    where TSymbol : ISymbol {
-    var references = AppDomain.CurrentDomain.GetAssemblies()
-      .Where(assembly => !assembly.IsDynamic)
-      .Select(assembly => MetadataReference.CreateFromFile(assembly.Location))
-      .Cast<MetadataReference>();
-
-    return (TSymbol)CSharpCompilation
-    .Create("AssemblyName")
-    .AddReferences(references)
-    .AddSyntaxTrees(tree)
-    .GetSemanticModel(tree)
-    .GetDeclaredSymbol(node)!;
-  }
-
   public static string LoadFixture(
     string relativePathInProject,
     [CallerFilePath] string? callerFilePath = null

--- a/Chickensoft.LogicBlocks.Analyzers/Chickensoft.LogicBlocks.Analyzers.csproj
+++ b/Chickensoft.LogicBlocks.Analyzers/Chickensoft.LogicBlocks.Analyzers.csproj
@@ -11,6 +11,7 @@
     <OutputPath>./nupkg</OutputPath>
     <IsRoslynComponent>true</IsRoslynComponent>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <DebugType>portable</DebugType>
 
     <Title>LogicBlocks Analyzers</Title>
@@ -39,9 +40,9 @@
   <!-- The following libraries include the types we need -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.24324.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-1.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0-1.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all">
     </PackageReference>
   </ItemGroup>

--- a/Chickensoft.LogicBlocks.Analyzers/README.md
+++ b/Chickensoft.LogicBlocks.Analyzers/README.md
@@ -1,3 +1,3 @@
 # Logic Blocks Analyzer
 
-Provides an analyzer and code fix for LogicBlocks.
+Provides an analyzer for LogicBlocks.

--- a/Chickensoft.LogicBlocks.CodeFixes/Chickensoft.LogicBlocks.CodeFixes.csproj
+++ b/Chickensoft.LogicBlocks.CodeFixes/Chickensoft.LogicBlocks.CodeFixes.csproj
@@ -25,14 +25,14 @@
     <PackageReleaseNotes>LogicBlocks CodeFixes release.</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>state management;bloc;godot;game;state machine</PackageTags>
-    <!-- <PackageReadmeFile>README.md</PackageReadmeFile> -->
+     <PackageReadmeFile>README.md</PackageReadmeFile> 
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/chickensoft-games/LogicBlocks</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Has to be in its own item group -->
-    <!-- <None Include="./README.md" Pack="true" PackagePath="\" /> -->
+     <None Include="./README.md" Pack="true" PackagePath="\" /> 
     <None Include="../LICENSE" Pack="true" PackagePath="\" />
     <None Include="../Chickensoft.LogicBlocks/icon.png" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/Chickensoft.LogicBlocks.CodeFixes/Chickensoft.LogicBlocks.CodeFixes.csproj
+++ b/Chickensoft.LogicBlocks.CodeFixes/Chickensoft.LogicBlocks.CodeFixes.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <LangVersion>preview</LangVersion>
-    <RootNamespace>Chickensoft.LogicBlocks.Analyzers</RootNamespace>
+    <RootNamespace>Chickensoft.LogicBlocks.CodeFixes</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>NU5128</NoWarn>
     <OutputPath>./nupkg</OutputPath>
@@ -14,32 +14,32 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <DebugType>portable</DebugType>
 
-    <Title>LogicBlocks Analyzers</Title>
+    <Title>LogicBlocks CodeFixes</Title>
     <Version>1.0.0</Version>
-    <Description>LogicBlocks analyzers.</Description>
+    <Description>LogicBlocks code fixes.</Description>
     <Copyright>© 2024 Chickensoft Games</Copyright>
     <Authors>Chickensoft</Authors>
     <Company>Chickensoft</Company>
 
-    <PackageId>Chickensoft.LogicBlocks.Analyzers</PackageId>
-    <PackageReleaseNotes>LogicBlocks Analyzers release.</PackageReleaseNotes>
+    <PackageId>Chickensoft.LogicBlocks.CodeFixes</PackageId>
+    <PackageReleaseNotes>LogicBlocks CodeFixes release.</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>state management;bloc;godot;game;state machine</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- <PackageReadmeFile>README.md</PackageReadmeFile> -->
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/chickensoft-games/LogicBlocks</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Has to be in its own item group -->
-    <None Include="./README.md" Pack="true" PackagePath="\" />
+    <!-- <None Include="./README.md" Pack="true" PackagePath="\" /> -->
     <None Include="../LICENSE" Pack="true" PackagePath="\" />
     <None Include="../Chickensoft.LogicBlocks/icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!-- The following libraries include the types we need -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->

--- a/Chickensoft.LogicBlocks.CodeFixes/README.md
+++ b/Chickensoft.LogicBlocks.CodeFixes/README.md
@@ -1,0 +1,3 @@
+# Logic Blocks Code Fixes
+
+Provides a code fix for LogicBlocks.

--- a/Chickensoft.LogicBlocks.CodeFixes/src/LogicBlockAttributeCodeFix.cs
+++ b/Chickensoft.LogicBlocks.CodeFixes/src/LogicBlockAttributeCodeFix.cs
@@ -1,11 +1,11 @@
-namespace Chickensoft.LogicBlocks.Analyzers;
+namespace Chickensoft.LogicBlocks.CodeFixes;
 
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Chickensoft.LogicBlocks.Analyzers.Utils;
+using Chickensoft.LogicBlocks.CodeFixes.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/Chickensoft.LogicBlocks.CodeFixes/src/utils/Constants.cs
+++ b/Chickensoft.LogicBlocks.CodeFixes/src/utils/Constants.cs
@@ -1,0 +1,5 @@
+namespace Chickensoft.LogicBlocks.CodeFixes.Utils;
+
+public static class Constants {
+  public const string LOGIC_BLOCK_ATTRIBUTE_NAME = "LogicBlock";
+}

--- a/Chickensoft.LogicBlocks.CodeFixes/src/utils/Diagnostics.cs
+++ b/Chickensoft.LogicBlocks.CodeFixes/src/utils/Diagnostics.cs
@@ -1,0 +1,25 @@
+namespace Chickensoft.LogicBlocks.CodeFixes.Utils;
+
+using Microsoft.CodeAnalysis;
+
+public static class Diagnostics {
+  public const string ERR_PREFIX = "LOGIC_BLOCKS";
+  public const string ERR_CATEGORY = "Chickensoft.LogicBlocks.CodeFixes";
+
+  public static DiagnosticDescriptor MissingLogicBlockAttributeDescriptor {
+    get;
+  } = new(
+    $"{ERR_PREFIX}_001",
+    $"Missing [{Constants.LOGIC_BLOCK_ATTRIBUTE_NAME}]",
+    messageFormat:
+      $"Missing [{Constants.LOGIC_BLOCK_ATTRIBUTE_NAME}] on logic block " +
+      "implementation `{0}`",
+    ERR_CATEGORY,
+    DiagnosticSeverity.Error,
+    isEnabledByDefault: true
+  );
+
+  public static Diagnostic MissingLogicBlockAttribute(
+    Location location, string name
+  ) => Diagnostic.Create(MissingLogicBlockAttributeDescriptor, location, name);
+}

--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/Chickensoft.LogicBlocks.DiagramGenerator.Tests.csproj
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/Chickensoft.LogicBlocks.DiagramGenerator.Tests.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.24324.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chickensoft.LogicBlocks.DiagramGenerator/Chickensoft.LogicBlocks.DiagramGenerator.csproj
+++ b/Chickensoft.LogicBlocks.DiagramGenerator/Chickensoft.LogicBlocks.DiagramGenerator.csproj
@@ -8,7 +8,8 @@
     <LangVersion>preview</LangVersion>
     <RootNamespace>Chickensoft.LogicBlocks.DiagramGenerator</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <NoWarn>NU5128</NoWarn>
+    <!-- RS1035: We're deliberately doing file output in an analyzer -->
+    <NoWarn>NU5128;RS1035</NoWarn>
     <OutputPath>./nupkg</OutputPath>
     <IsRoslynComponent>true</IsRoslynComponent>
     <AnalyzerLanguage>cs</AnalyzerLanguage>

--- a/Chickensoft.LogicBlocks.DiagramGenerator/Chickensoft.LogicBlocks.DiagramGenerator.csproj
+++ b/Chickensoft.LogicBlocks.DiagramGenerator/Chickensoft.LogicBlocks.DiagramGenerator.csproj
@@ -12,6 +12,7 @@
     <OutputPath>./nupkg</OutputPath>
     <IsRoslynComponent>true</IsRoslynComponent>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <DebugType>portable</DebugType>
 
     <Title>LogicBlocks Generator</Title>
@@ -44,7 +45,7 @@
   <!-- The following libraries include the source generator interfaces and types we need -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.24324.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all">
     </PackageReference>
   </ItemGroup>

--- a/Chickensoft.LogicBlocks.Example/Chickensoft.LogicBlocks.Example.csproj
+++ b/Chickensoft.LogicBlocks.Example/Chickensoft.LogicBlocks.Example.csproj
@@ -21,6 +21,7 @@
 
     <ProjectReference Include="../Chickensoft.LogicBlocks/Chickensoft.LogicBlocks.csproj" />
     <ProjectReference Include="../Chickensoft.LogicBlocks.DiagramGenerator/Chickensoft.LogicBlocks.DiagramGenerator.csproj" PrivateAssets="all" OutputItemType="analyzer" />
+    <ProjectReference Include="../Chickensoft.LogicBlocks.CodeFixes/Chickensoft.LogicBlocks.CodeFixes.csproj" PrivateAssets="all" OutputItemType="analyzer" />
     <ProjectReference Include="../Chickensoft.LogicBlocks.Analyzers/Chickensoft.LogicBlocks.Analyzers.csproj" PrivateAssets="all" OutputItemType="analyzer" />
   </ItemGroup>
 

--- a/Chickensoft.LogicBlocks.sln
+++ b/Chickensoft.LogicBlocks.sln
@@ -3,31 +3,30 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks", "Chickensoft.LogicBlocks\Chickensoft.LogicBlocks.csproj", "{B3B047A2-6F61-416C-8F46-3B6E3E8F35F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks", "Chickensoft.LogicBlocks\Chickensoft.LogicBlocks.csproj", "{B3B047A2-6F61-416C-8F46-3B6E3E8F35F9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.Tests", "Chickensoft.LogicBlocks.Tests\Chickensoft.LogicBlocks.Tests.csproj", "{00414FB6-7CE0-4CE5-AEF5-A963FD93EE6D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.Tests", "Chickensoft.LogicBlocks.Tests\Chickensoft.LogicBlocks.Tests.csproj", "{00414FB6-7CE0-4CE5-AEF5-A963FD93EE6D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.Example", "Chickensoft.LogicBlocks.Example\Chickensoft.LogicBlocks.Example.csproj", "{B1161A42-CC61-4238-9E34-007A37C84841}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.Example", "Chickensoft.LogicBlocks.Example\Chickensoft.LogicBlocks.Example.csproj", "{B1161A42-CC61-4238-9E34-007A37C84841}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.DiagramGenerator", "Chickensoft.LogicBlocks.DiagramGenerator\Chickensoft.LogicBlocks.DiagramGenerator.csproj", "{D6C4E778-70FF-461C-A59C-F3668C175602}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.DiagramGenerator", "Chickensoft.LogicBlocks.DiagramGenerator\Chickensoft.LogicBlocks.DiagramGenerator.csproj", "{D6C4E778-70FF-461C-A59C-F3668C175602}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.DiagramGenerator.Tests", "Chickensoft.LogicBlocks.DiagramGenerator.Tests\Chickensoft.LogicBlocks.DiagramGenerator.Tests.csproj", "{D8CB5FA1-4748-4BAF-BB93-88B4C5CF272A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.DiagramGenerator.Tests", "Chickensoft.LogicBlocks.DiagramGenerator.Tests\Chickensoft.LogicBlocks.DiagramGenerator.Tests.csproj", "{D8CB5FA1-4748-4BAF-BB93-88B4C5CF272A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.GeneratorTester", "Chickensoft.GeneratorTester\Chickensoft.GeneratorTester.csproj", "{33A2BAAC-5FAC-4869-B901-45286A1B54A8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.GeneratorTester", "Chickensoft.GeneratorTester\Chickensoft.GeneratorTester.csproj", "{33A2BAAC-5FAC-4869-B901-45286A1B54A8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.Analyzers", "Chickensoft.LogicBlocks.Analyzers\Chickensoft.LogicBlocks.Analyzers.csproj", "{FC526459-EB9E-4B81-B0BA-C3B3FD1BCAF7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.Analyzers", "Chickensoft.LogicBlocks.Analyzers\Chickensoft.LogicBlocks.Analyzers.csproj", "{FC526459-EB9E-4B81-B0BA-C3B3FD1BCAF7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.Tutorial", "Chickensoft.LogicBlocks.Tutorial\Chickensoft.LogicBlocks.Tutorial.csproj", "{16494DAA-416E-47C5-9A31-A9D27C6DAD21}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.Tutorial", "Chickensoft.LogicBlocks.Tutorial\Chickensoft.LogicBlocks.Tutorial.csproj", "{16494DAA-416E-47C5-9A31-A9D27C6DAD21}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.LogicBlocks.Tutorial.Tests", "Chickensoft.LogicBlocks.Tutorial.Tests\Chickensoft.LogicBlocks.Tutorial.Tests.csproj", "{791115C7-7CFA-46D6-AD17-E8A276E6BF9B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.Tutorial.Tests", "Chickensoft.LogicBlocks.Tutorial.Tests\Chickensoft.LogicBlocks.Tutorial.Tests.csproj", "{791115C7-7CFA-46D6-AD17-E8A276E6BF9B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chickensoft.LogicBlocks.CodeFixes", "Chickensoft.LogicBlocks.CodeFixes\Chickensoft.LogicBlocks.CodeFixes.csproj", "{80917C18-73A5-4032-96C5-AC40A7E0DD3A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B3B047A2-6F61-416C-8F46-3B6E3E8F35F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -66,5 +65,12 @@ Global
 		{791115C7-7CFA-46D6-AD17-E8A276E6BF9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{791115C7-7CFA-46D6-AD17-E8A276E6BF9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{791115C7-7CFA-46D6-AD17-E8A276E6BF9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80917C18-73A5-4032-96C5-AC40A7E0DD3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80917C18-73A5-4032-96C5-AC40A7E0DD3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80917C18-73A5-4032-96C5-AC40A7E0DD3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80917C18-73A5-4032-96C5-AC40A7E0DD3A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/Chickensoft.LogicBlocks/Chickensoft.LogicBlocks.csproj
+++ b/Chickensoft.LogicBlocks/Chickensoft.LogicBlocks.csproj
@@ -66,11 +66,18 @@
           <OutputItemType>Content</OutputItemType>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </ProjectReference>
+    <ProjectReference Include="..\Chickensoft.LogicBlocks.CodeFixes\Chickensoft.LogicBlocks.CodeFixes.csproj" Pack="false">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="$(OutputPath)/Chickensoft.LogicBlocks.Analyzers.dll" />
     <None Include="$(OutputPath)/Chickensoft.LogicBlocks.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Remove="$(OutputPath)/Chickensoft.LogicBlocks.CodeFixes.dll" />
+    <None Include="$(OutputPath)/Chickensoft.LogicBlocks.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <!-- Include the stuff inside ./buildTransitive so our props get picked up by consuming packages -->


### PR DESCRIPTION
I would advocate testing this locally before merging, or at least double-checking my work setting up the new code-fix analyzer.

Analyzers/generators in LogicBlocks depend on v4.12.0-final of Microsoft.CodeAnalysis packages. That causes the resulting DLLs to reference v4.12.0 of the compiler, which is newer than v4.11.0 currently shipped. That in turn causes a `CS9057` warning both when compiling LogicBlocks projects that depend on the analyzers, and in user projects referencing LogicBlocks:

![Screenshot 2024-09-03 155853](https://github.com/user-attachments/assets/5e6c8831-4cd2-4ddd-add2-d8ee81016cbb)

To fix this, I've rolled back those Microsoft.CodeAnalysis references to v4.11. This in turn causes the compiler to warn that analyzers and generators should now have the project property `EnforceExtendedAnalyzerRules` turned on:

![Screenshot 2024-09-03 160135](https://github.com/user-attachments/assets/de59dd4c-ff29-49c9-8f69-39f19dec24f8)

After enabling that property, other warnings are generated, notably RS1038 in LogicBlocks.Analyzers and RS1035 in LogicBlocks.DiagramGenerator:

## RS1038
![Screenshot 2024-09-03 163359](https://github.com/user-attachments/assets/07a0a0f1-3d07-4a19-924e-ef6149131376)

A (new?) rule provides that analyzers and code fixes shouldn't exist in the same assembly, since code fixes rely on the Workspace package, which is not available on the command-line. To rectify this, I've moved the code fix into a separate assembly, LogicBlocks.CodeFixes. Additionally, I've put a reference to the new analyzer in the Example project, and I've also [included it into the main LogicBlocks package](https://github.com/wlsnmrk/LogicBlocks/blob/4029ede65c0c5199ee567c6de3008a9768621a9b/Chickensoft.LogicBlocks/Chickensoft.LogicBlocks.csproj#L79).

I've used `ProjectReference`s in one of my own local projects to verify that IntelliSense and the compiler still pick up the error about the missing `[LogicBlock]` attribute with the split-out code-fix analyzer:

![Screenshot 2024-09-03 165634](https://github.com/user-attachments/assets/08850786-df6c-4556-9ae6-99509470c38a)

## RS1035
This warns that analyzers should not do file I/O. Since that's the whole purpose of the DiagramGenerator project, I don't see a fix or a workaround for this. Therefore I've just suppressed it in the project settings. (There's also an instance of the same warning enforcing that analyzers should not access `Environment` properties, referring to the use of `Environment.NewLine`. However, issue 6467 at the dotnet/roslyn-analyzers project contains an open discussion about whether `NewLine` should be an exception, so I haven't changed anything there.)

## RS1039
This was warning that the `Tester.GetSymbol` method, in GeneratorTester, invoked `SemanticModel.GetDeclaredSymbol` on a `SyntaxNode`, which always returns null for certain subclasses of `SyntaxNode`. However, that code was unused, so I've removed it rather than address nullability or anything.