### PR TITLE
chore: disallow "final" preview dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "groupName": "all dependencies",
       "groupSlug": "all-deps",
       "automerge": true,
-      "allowedVersions": "!/preview/"
+      "allowedVersions": "!/(preview|final)/"
     },
     {
       "matchPackagePrefixes": [


### PR DESCRIPTION
Updated renovate settings to disallow nuget packages marked "final" from being pulled into the dependencies, to avoid issues with .NET compiler/analyzer packages (such as those corrected in #69).