### PR TITLE
chore(dotnet): Upgrade from net7.0 to net8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,17 @@ coverage/
 nupkg/
 .generated/
 .vs/
+.idea/
 .DS_Store
 *.DotSettings.user
 *.binlog
+
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs

--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/Chickensoft.LogicBlocks.DiagramGenerator.Tests.csproj
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/Chickensoft.LogicBlocks.DiagramGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Chickensoft.LogicBlocks.Example/Chickensoft.LogicBlocks.Example.csproj
+++ b/Chickensoft.LogicBlocks.Example/Chickensoft.LogicBlocks.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>

--- a/Chickensoft.LogicBlocks.Tests/Chickensoft.LogicBlocks.Tests.csproj
+++ b/Chickensoft.LogicBlocks.Tests/Chickensoft.LogicBlocks.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Chickensoft.LogicBlocks.Tutorial.Tests/Chickensoft.LogicBlocks.Tutorial.Tests.csproj
+++ b/Chickensoft.LogicBlocks.Tutorial.Tests/Chickensoft.LogicBlocks.Tutorial.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "7.0.410"
+    "version": "8.0.400"
   }
 }


### PR DESCRIPTION
dotnet 7.0 is no longer maintained, and has reached EOL. dotnet 8.0 is the LTS version, and will be supported until November 2026.

[dotnet support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)

Testing

- [x] 100% test coverage on logic blocks
- [x] 100% test coverage on serialization
- [x] 100% test coverage on introspection
- [x] serialization integration tests
- [x] introspection generator use case tests
- [x] diagram generator use case tests