### PR TITLE
chore: fix truncated build issues in vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,7 @@
       "type": "process",
       "args": [
         "build",
+        "/consoleloggerparameters:ForceNoAlign"
       ],
       "problemMatcher": "$msCompile",
       "presentation": {


### PR DESCRIPTION
In VSCode (on WIndows 11, with .NET 8), build issues (e.g., warnings) are displayed in the "Problems" tab with truncated filenames and messages:
![Screenshot 2024-10-15 150634](https://github.com/user-attachments/assets/e7974054-6948-41a7-b3ce-5c7da165e65d)

In addition, clicking the issue attempts to open the displayed (incorrect filename):
![Screenshot 2024-10-15 150646](https://github.com/user-attachments/assets/c3dfdc5c-e68f-4374-9127-16d07d0b2b90)

![Screenshot 2024-10-15 150653](https://github.com/user-attachments/assets/3b9170a4-5917-4c38-a889-144ccf660bbf)

---
The issue appears to be that VSCode's problem matcher can't handle line wrapping in the terminal output of the build task (see [this C# extension issue](/dotnet/vscode-csharp/issues/6309) and [this VSCode issue](/microsoft/vscode/issues/150285)):
![Screenshot 2024-10-15 214106](https://github.com/user-attachments/assets/3685f4c5-d4ce-469e-93b3-66bec743b74f)

---
This PR modifies the build task to pass `/consoleloggerparameters:ForceNoAlign` option to dotnet build, recommended as a workaround in the above issues. This option prevents the terminal output from wrapping, and build issues appear as expected:
![Screenshot 2024-10-15 214043](https://github.com/user-attachments/assets/ee362e34-c241-4950-befc-7c7fb5cff2f8)
