### PR TITLE
Fix an infinite loop caused when creating input in OnStart

### DIFF
--- a/Chickensoft.LogicBlocks.Tests/test/src/LogicBlockTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/LogicBlockTest.cs
@@ -374,6 +374,27 @@ public partial class LogicBlockTest {
   }
 
   [Fact]
+  public void OnStartDoesNotCauseInfiniteLoopWithInput() {
+    var onStartCalled = false;
+    var looped = false;
+    var logic = new FakeLogicBlock();
+    logic.OnStartCalled += () => {
+      if (onStartCalled) {
+        looped = true;
+        return;
+      }
+
+      onStartCalled = true;
+      logic.Input(new FakeLogicBlock.Input.InputOne(2, 3));
+    };
+
+    logic.Start();
+
+    onStartCalled.ShouldBeTrue();
+    looped.ShouldBeFalse();
+  }
+
+  [Fact]
   public void StopExitsState() {
     var exitCalled = false;
     var onStopCalled = false;

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -400,10 +400,10 @@ ILogicBlock<TState>, IBoxlessValueHandler where TState : StateLogic<TState> {
 
     if (_value is null) {
       // No state yet. Let's get the first state going!
-      OnStart();
       Blackboard.InstantiateAnyMissingSavedData();
       ChangeState(RestoredState as TState ?? GetInitialState().State);
       RestoredState = null;
+      OnStart();
     }
 
     // We can always process the first input directly.


### PR DESCRIPTION
If `OnStart` triggers an `Input` call, an infinite (until max stack depth) loop occurs. This is because `OnStart` is called before the initial state value is set. When `Input` attempts to return the current value of the LogicBlock via the `Value` property, it falls back to calling `Flush` when the backing field is `null`.