### PR TITLE
chore: keep OnEnter/OnExit from being suggested for every type

### DIFF
--- a/Chickensoft.LogicBlocks/src/StateLogicExtensions.cs
+++ b/Chickensoft.LogicBlocks/src/StateLogicExtensions.cs
@@ -47,7 +47,7 @@ public static class StateLogicExtensions {
     Action<TBaseState?> handler
   )
   where TBaseState : StateBase
-  where TDerivedState : TBaseState =>
+  where TDerivedState : StateBase, TBaseState =>
     state.OnEnter<TDerivedState>((previous) => handler(previous as TBaseState));
 
   /// <summary>
@@ -91,6 +91,6 @@ public static class StateLogicExtensions {
     Action<TBaseState?> handler
   )
   where TBaseState : StateBase
-  where TDerivedState : TBaseState =>
+  where TDerivedState : StateBase, TBaseState =>
     state.OnExit<TDerivedState>((next) => handler(next as TBaseState));
 }


### PR DESCRIPTION
OnEnter/OnExit extension methods were being suggested for every type (`object`, `int`, `List`, etc)

![Screen Shot 2025-04-06 at 14 32 55 PM](https://github.com/user-attachments/assets/27fe6b54-931d-4442-9ff4-4d4d1154e5a8)
