### PR TITLE
chore: stabilize puml generation

### DIFF
--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/CallOrderExample.g.puml
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/CallOrderExample.g.puml
@@ -1,8 +1,8 @@
 @startuml CallOrderExample
 state "CallOrderExample State" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_State {
   state "Active" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_Active {
-    state "Walking" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_Walking
     state "Running" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_Running
+    state "Walking" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_Walking
   }
   state "Inactive" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_Inactive {
     state "Standing" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_CallOrderExample_Standing

--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/Heater.g.puml
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/Heater.g.puml
@@ -1,10 +1,10 @@
 @startuml Heater
 state "Heater State" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State {
-  state "Powered" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Powered {
-    state "Idle" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Idle
-    state "Heating" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Heating
-  }
   state "Off" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Off
+  state "Powered" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Powered {
+    state "Heating" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Heating
+    state "Idle" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State_Idle
+  }
 }
 
 Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State --> Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Heater_State : TargetTempChanged

--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/Patterns.g.puml
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/Patterns.g.puml
@@ -1,8 +1,8 @@
 @startuml Patterns
 state "Patterns State" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State {
   state "One" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State_One
-  state "Two" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State_Two
   state "Three" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State_Three
+  state "Two" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State_Two
 }
 
 Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State --> Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_Patterns_State_One : SetMode

--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/ToasterOven.g.puml
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/ToasterOven.g.puml
@@ -1,10 +1,10 @@
 @startuml ToasterOven
 state "ToasterOven State" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State {
-  state "Heating" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Heating {
-    state "Toasting" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Toasting
-    state "Baking" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Baking
-  }
   state "DoorOpen" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_DoorOpen
+  state "Heating" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Heating {
+    state "Baking" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Baking
+    state "Toasting" as Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Toasting
+  }
 }
 
 Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Baking --> Chickensoft_LogicBlocks_DiagramGenerator_Tests_TestCases_ToasterOven_State_Toasting : StartToasting

--- a/Chickensoft.LogicBlocks.DiagramGenerator/src/Diagrammer.cs
+++ b/Chickensoft.LogicBlocks.DiagramGenerator/src/Diagrammer.cs
@@ -458,7 +458,7 @@ public class Diagrammer : ChickensoftGenerator, IIncrementalGenerator {
       lines.Add($"{Tab(t)}state \"{graph.Name}\" as {graph.UmlId}");
     }
 
-    foreach (var child in graph.Children) {
+    foreach (var child in graph.Children.OrderBy(child => child.Name)) {
       lines.AddRange(
         WriteGraph(child, impl, stateDescriptions, t + 1)
       );

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/FakeLogicBlock.g.puml
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/FakeLogicBlock.g.puml
@@ -1,14 +1,14 @@
 @startuml FakeLogicBlock
 state "FakeLogicBlock State" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State {
+  state "AddErrorOnEnterState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_AddErrorOnEnterState
+  state "NothingState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_NothingState
+  state "OnEnterState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_OnEnterState
+  state "OnExitState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_OnExitState
   state "StartState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_StartState
   state "StateA" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_StateA
   state "StateB" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_StateB
   state "StateC" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_StateC
   state "StateD" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_StateD
-  state "NothingState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_NothingState
-  state "OnEnterState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_OnEnterState
-  state "OnExitState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_OnExitState
-  state "AddErrorOnEnterState" as Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State_AddErrorOnEnterState
 }
 
 Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State --> Chickensoft_LogicBlocks_Tests_Fixtures_FakeLogicBlock_State : NoNewState

--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/MyLogicBlock.g.puml
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/MyLogicBlock.g.puml
@@ -1,7 +1,7 @@
 @startuml MyLogicBlock
 state "MyLogicBlock State" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State {
-  state "SomeState" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState
   state "SomeOtherState" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeOtherState
+  state "SomeState" as Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState
 }
 
 Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeOtherState --> Chickensoft_LogicBlocks_Tests_Fixtures_MyLogicBlock_State_SomeState : SomeOtherInput

--- a/Chickensoft.LogicBlocks.Tests/test/src/LightSwitchMeta.g.puml
+++ b/Chickensoft.LogicBlocks.Tests/test/src/LightSwitchMeta.g.puml
@@ -1,7 +1,7 @@
 @startuml LightSwitch
 state "LightSwitch State" as Chickensoft_LogicBlocks_Tests_Examples_LightSwitch_State {
-  state "PoweredOn" as Chickensoft_LogicBlocks_Tests_Examples_LightSwitch_State_PoweredOn
   state "PoweredOff" as Chickensoft_LogicBlocks_Tests_Examples_LightSwitch_State_PoweredOff
+  state "PoweredOn" as Chickensoft_LogicBlocks_Tests_Examples_LightSwitch_State_PoweredOn
 }
 
 Chickensoft_LogicBlocks_Tests_Examples_LightSwitch_State_PoweredOff --> Chickensoft_LogicBlocks_Tests_Examples_LightSwitch_State_PoweredOn : Toggle

--- a/Chickensoft.LogicBlocks.Tests/test/src/examples/LightSwitchStandard.g.puml
+++ b/Chickensoft.LogicBlocks.Tests/test/src/examples/LightSwitchStandard.g.puml
@@ -1,7 +1,7 @@
 @startuml LightSwitch
 state "LightSwitch State" as Chickensoft_LogicBlocks_Tests_Examples_Misc_LightSwitch_State {
-  state "PoweredOn" as Chickensoft_LogicBlocks_Tests_Examples_Misc_LightSwitch_State_PoweredOn
   state "PoweredOff" as Chickensoft_LogicBlocks_Tests_Examples_Misc_LightSwitch_State_PoweredOff
+  state "PoweredOn" as Chickensoft_LogicBlocks_Tests_Examples_Misc_LightSwitch_State_PoweredOn
 }
 
 Chickensoft_LogicBlocks_Tests_Examples_Misc_LightSwitch_State_PoweredOff --> Chickensoft_LogicBlocks_Tests_Examples_Misc_LightSwitch_State_PoweredOn : Toggle


### PR DESCRIPTION
This addresses #143 where states aren't deterministically ordered in the puml output.