### PR TITLE
fix: informative exception message when state retrieval fails

### DIFF
--- a/Chickensoft.LogicBlocks.Tests/test/fixtures/MissingMetaLogicBlock.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/fixtures/MissingMetaLogicBlock.cs
@@ -1,0 +1,8 @@
+namespace Chickensoft.LogicBlocks.Tests.Fixtures;
+
+[LogicBlock(typeof(State), Diagram = false)]
+public partial class MissingMetaLogicBlock : LogicBlock<MissingMetaLogicBlock.State> {
+  public override Transition GetInitialState() => To<State>();
+
+  public partial record State : StateLogic<State>;
+}

--- a/Chickensoft.LogicBlocks.Tests/test/src/LogicBlockTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/test/src/LogicBlockTest.cs
@@ -82,6 +82,12 @@ public partial class LogicBlockTest {
   }
 
   [Fact]
+  public void ThrowsWithInformativeMessageIfStateNotInBlackboard() {
+    var block = new MissingMetaLogicBlock();
+    Should.Throw<InvalidOperationException>(block.Start, "Could not retrieve state MissingMetaLogicBlock+State. You may need to add the Meta attribute to your LogicBlock, or add the states to the blackboard manually.");
+  }
+
+  [Fact]
   public void InvokesInputEvent() {
     var block = new FakeLogicBlock();
     using var listener = Listen(block);

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -355,7 +355,18 @@ ILogicBlock<TState>, IBoxlessValueHandler where TState : StateLogic<TState> {
   /// </summary>
   /// <typeparam name="TStateType">Type of state to transition to.</typeparam>
   protected Transition To<TStateType>()
-    where TStateType : TState => new(Context.Get<TStateType>());
+      where TStateType : TState {
+    try {
+      return new(Context.Get<TStateType>());
+    }
+    catch (Exception e) {
+      throw new InvalidOperationException(
+        $"Could not retrieve state {typeof(TStateType)}. You may need to add the Meta attribute to your LogicBlock, or add the states to the blackboard manually.",
+        e
+      );
+    }
+  }
+
 
   #region IReadOnlyBlackboard
   /// <inheritdoc />


### PR DESCRIPTION
Provides an informative exception message when the LogicBlock.To() method fails to retrieve a state from the blackboard, reminding the user that they may need to add the Meta attribute to the logic block.