### PR TITLE
feature: Standardize State Change

### DIFF
--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/HeaterTest.cs
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/HeaterTest.cs
@@ -81,8 +81,10 @@ public class HeaterTest
       "Heater turned off",
       "Heater is powered",
       "Heater is idling",
+      "Heater is powered",
       "Heater is heating",
       "Finished heating :)",
+      "Heater is powered",
       "Heater is idling"
     ]);
   }

--- a/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/HeaterTest.cs
+++ b/Chickensoft.LogicBlocks.DiagramGenerator.Tests/test_cases/HeaterTest.cs
@@ -81,10 +81,8 @@ public class HeaterTest
       "Heater turned off",
       "Heater is powered",
       "Heater is idling",
-      "Heater is powered",
       "Heater is heating",
       "Finished heating :)",
-      "Heater is powered",
       "Heater is idling"
     ]);
   }

--- a/Chickensoft.LogicBlocks.Tests/src/FakeBindingTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/src/FakeBindingTest.cs
@@ -55,7 +55,7 @@ public class FakeBindingTest
     binding.OnEnter<TestLogicBlockState>(state => received = state);
 
     var state = new TestLogicBlockState();
-    binding.SetEnterState(state);
+    binding.EnterState(state);
 
     received.ShouldBeSameAs(state);
   }
@@ -67,7 +67,7 @@ public class FakeBindingTest
     var fired = false;
 
     binding.OnEnter<TestLogicBlockState.OutputtingState>(_ => fired = true);
-    binding.SetEnterState(new TestLogicBlockState());
+    binding.EnterState(new TestLogicBlockState());
 
     fired.ShouldBeFalse();
   }
@@ -79,7 +79,7 @@ public class FakeBindingTest
     var fired = false;
 
     binding.OnEnter<TestLogicBlockState>(_ => fired = true);
-    binding.SetEnterState(new TestLogicBlockState.SubState(), new TestLogicBlockState());
+    binding.EnterState(new TestLogicBlockState.SubState(), new TestLogicBlockState());
 
     fired.ShouldBeFalse();
   }
@@ -93,7 +93,7 @@ public class FakeBindingTest
     binding.OnExit<TestLogicBlockState>(state => received = state);
 
     var state = new TestLogicBlockState();
-    binding.SetExitState(state);
+    binding.ExitState(state);
 
     received.ShouldBeSameAs(state);
   }
@@ -105,7 +105,7 @@ public class FakeBindingTest
     var fired = false;
 
     binding.OnExit<TestLogicBlockState.OutputtingState>(_ => fired = true);
-    binding.SetExitState(new TestLogicBlockState());
+    binding.ExitState(new TestLogicBlockState());
 
     fired.ShouldBeFalse();
   }
@@ -117,7 +117,7 @@ public class FakeBindingTest
     var fired = false;
 
     binding.OnExit<TestLogicBlockState>(_ => fired = true);
-    binding.SetExitState(new TestLogicBlockState(), new TestLogicBlockState.SubState());
+    binding.ExitState(new TestLogicBlockState(), new TestLogicBlockState.SubState());
 
     fired.ShouldBeFalse();
   }

--- a/Chickensoft.LogicBlocks.Tests/src/FakeBindingTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/src/FakeBindingTest.cs
@@ -35,6 +35,20 @@ public class FakeBindingTest
   }
 
   [Fact]
+  public void StateFiresOnExitStateCallback()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    TestLogicBlockState? received = null;
+
+    binding.OnExitState<TestLogicBlockState>(state => received = state);
+
+    var state = new TestLogicBlockState();
+    binding.SetExitState(state);
+
+    received.ShouldBeSameAs(state);
+  }
+
+  [Fact]
   public void StateDoesNotFireForNonMatchingType()
   {
     using var binding = LogicBlock.CreateFakeBinding();
@@ -42,6 +56,42 @@ public class FakeBindingTest
 
     binding.OnState<TestLogicBlockState.OutputtingState>(_ => fired = true);
     binding.SetState(new TestLogicBlockState());
+
+    fired.ShouldBeFalse();
+  }
+
+  [Fact]
+  public void StateExitDoesNotFireForNonMatchingType()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    var fired = false;
+
+    binding.OnExitState<TestLogicBlockState.OutputtingState>(_ => fired = true);
+    binding.SetExitState(new TestLogicBlockState());
+
+    fired.ShouldBeFalse();
+  }
+
+  [Fact]
+  public void StateDoesNotFireForDerivedType()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    var fired = false;
+
+    binding.OnState<TestLogicBlockState>(_ => fired = true);
+    binding.SetState(new TestLogicBlockState.SubState(), new TestLogicBlockState());
+
+    fired.ShouldBeFalse();
+  }
+
+  [Fact]
+  public void StateExitDoesNotFireForDerivedType()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    var fired = false;
+
+    binding.OnExitState<TestLogicBlockState>(_ => fired = true);
+    binding.SetExitState(new TestLogicBlockState(), new TestLogicBlockState.SubState());
 
     fired.ShouldBeFalse();
   }

--- a/Chickensoft.LogicBlocks.Tests/src/FakeBindingTest.cs
+++ b/Chickensoft.LogicBlocks.Tests/src/FakeBindingTest.cs
@@ -35,20 +35,6 @@ public class FakeBindingTest
   }
 
   [Fact]
-  public void StateFiresOnExitStateCallback()
-  {
-    using var binding = LogicBlock.CreateFakeBinding();
-    TestLogicBlockState? received = null;
-
-    binding.OnExitState<TestLogicBlockState>(state => received = state);
-
-    var state = new TestLogicBlockState();
-    binding.SetExitState(state);
-
-    received.ShouldBeSameAs(state);
-  }
-
-  [Fact]
   public void StateDoesNotFireForNonMatchingType()
   {
     using var binding = LogicBlock.CreateFakeBinding();
@@ -61,25 +47,65 @@ public class FakeBindingTest
   }
 
   [Fact]
-  public void StateExitDoesNotFireForNonMatchingType()
+  public void StateEnterFiresOnStateCallback()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    TestLogicBlockState? received = null;
+
+    binding.OnEnter<TestLogicBlockState>(state => received = state);
+
+    var state = new TestLogicBlockState();
+    binding.SetEnterState(state);
+
+    received.ShouldBeSameAs(state);
+  }
+
+  [Fact]
+  public void StateEnterDoesNotFireForNonMatchingType()
   {
     using var binding = LogicBlock.CreateFakeBinding();
     var fired = false;
 
-    binding.OnExitState<TestLogicBlockState.OutputtingState>(_ => fired = true);
-    binding.SetExitState(new TestLogicBlockState());
+    binding.OnEnter<TestLogicBlockState.OutputtingState>(_ => fired = true);
+    binding.SetEnterState(new TestLogicBlockState());
 
     fired.ShouldBeFalse();
   }
 
   [Fact]
-  public void StateDoesNotFireForDerivedType()
+  public void StateEnterDoesNotFireForDerivedType()
   {
     using var binding = LogicBlock.CreateFakeBinding();
     var fired = false;
 
-    binding.OnState<TestLogicBlockState>(_ => fired = true);
-    binding.SetState(new TestLogicBlockState.SubState(), new TestLogicBlockState());
+    binding.OnEnter<TestLogicBlockState>(_ => fired = true);
+    binding.SetEnterState(new TestLogicBlockState.SubState(), new TestLogicBlockState());
+
+    fired.ShouldBeFalse();
+  }
+
+  [Fact]
+  public void StateFiresOnExitStateCallback()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    TestLogicBlockState? received = null;
+
+    binding.OnExit<TestLogicBlockState>(state => received = state);
+
+    var state = new TestLogicBlockState();
+    binding.SetExitState(state);
+
+    received.ShouldBeSameAs(state);
+  }
+
+  [Fact]
+  public void StateExitDoesNotFireForNonMatchingType()
+  {
+    using var binding = LogicBlock.CreateFakeBinding();
+    var fired = false;
+
+    binding.OnExit<TestLogicBlockState.OutputtingState>(_ => fired = true);
+    binding.SetExitState(new TestLogicBlockState());
 
     fired.ShouldBeFalse();
   }
@@ -90,7 +116,7 @@ public class FakeBindingTest
     using var binding = LogicBlock.CreateFakeBinding();
     var fired = false;
 
-    binding.OnExitState<TestLogicBlockState>(_ => fired = true);
+    binding.OnExit<TestLogicBlockState>(_ => fired = true);
     binding.SetExitState(new TestLogicBlockState(), new TestLogicBlockState.SubState());
 
     fired.ShouldBeFalse();

--- a/Chickensoft.LogicBlocks.Tests/src/fixtures/TestLogicBlock.cs
+++ b/Chickensoft.LogicBlocks.Tests/src/fixtures/TestLogicBlock.cs
@@ -43,6 +43,8 @@ public record TestLogicBlockState : LogicBlockState,
     return ToSelf();
   }
 
+  public record SubState : TestLogicBlockState;
+
   public record OutputtingState : TestLogicBlockState,
     IGet<Input.TestInput>
   {

--- a/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
@@ -14,7 +14,9 @@ public partial class LogicBlock
   private readonly record struct
     InputBroadcast<TInput>(in TInput Input) where TInput : struct;
 
-  private readonly record struct StateBroadcast(object State);
+  private readonly record struct StateBroadcast(object State, object? Previous);
+
+  private readonly record struct ExitStateBroadcast(object State, object? Next);
 
   private readonly record struct
     OutputBroadcast<TOutput>(in TOutput Output) where TOutput : struct;
@@ -45,7 +47,20 @@ public partial class LogicBlock
     {
       AddCallback(
         (in StateBroadcast broadcast) => callback((TState)broadcast.State),
-        (in StateBroadcast broadcast) => broadcast.State is TState
+        (in StateBroadcast broadcast) =>
+          broadcast.Previous is not TState && broadcast.State is TState
+      );
+
+      return this;
+    }
+
+    public Binding OnExitState<TState>(Action<TState> callback)
+      where TState : LogicBlockState
+    {
+      AddCallback(
+        (in ExitStateBroadcast broadcast) => callback((TState)broadcast.State),
+        (in ExitStateBroadcast broadcast) =>
+          broadcast.Next is not TState && broadcast.State is TState
       );
 
       return this;
@@ -104,9 +119,14 @@ public partial class LogicBlock
       _fakeSubject.Broadcast(new InputBroadcast<TInput>(input));
 
     /// <summary>Simulates a state change.</summary>
-    public void SetState<TState>(TState state)
+    public void SetState<TState>(TState state, LogicBlockState? previous = null)
       where TState : LogicBlockState =>
-      _fakeSubject.Broadcast(new StateBroadcast(state));
+      _fakeSubject.Broadcast(new StateBroadcast(state, previous));
+
+    /// <summary>Simulates a state exit.</summary>
+    public void ExitState<TState>(TState state, LogicBlockState? next = null)
+      where TState : LogicBlockState =>
+      _fakeSubject.Broadcast(new StateBroadcast(state, next));
 
     /// <summary>Simulates an output being produced.</summary>
     public void Output<TOutput>(in TOutput output)

--- a/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
@@ -14,7 +14,9 @@ public partial class LogicBlock
   private readonly record struct
     InputBroadcast<TInput>(in TInput Input) where TInput : struct;
 
-  private readonly record struct StateBroadcast(object State, object? Previous);
+  private readonly record struct StateBroadcast(object State);
+
+  private readonly record struct EnterStateBroadcast(object State, object? Previous);
 
   private readonly record struct ExitStateBroadcast(object State, object? Next);
 
@@ -47,14 +49,25 @@ public partial class LogicBlock
     {
       AddCallback(
         (in StateBroadcast broadcast) => callback((TState)broadcast.State),
-        (in StateBroadcast broadcast) =>
+        (in StateBroadcast broadcast) => broadcast.State is TState
+      );
+
+      return this;
+    }
+
+    public Binding OnEnter<TState>(Action<TState> callback)
+      where TState : LogicBlockState
+    {
+      AddCallback(
+        (in EnterStateBroadcast broadcast) => callback((TState)broadcast.State),
+        (in EnterStateBroadcast broadcast) =>
           broadcast.Previous is not TState && broadcast.State is TState
       );
 
       return this;
     }
 
-    public Binding OnExitState<TState>(Action<TState> callback)
+    public Binding OnExit<TState>(Action<TState> callback)
       where TState : LogicBlockState
     {
       AddCallback(
@@ -119,9 +132,14 @@ public partial class LogicBlock
       _fakeSubject.Broadcast(new InputBroadcast<TInput>(input));
 
     /// <summary>Simulates a state change.</summary>
-    public void SetState<TState>(TState state, LogicBlockState? previous = null)
+    public void SetState<TState>(TState state)
       where TState : LogicBlockState =>
-      _fakeSubject.Broadcast(new StateBroadcast(state, previous));
+      _fakeSubject.Broadcast(new StateBroadcast(state));
+
+    /// <summary>Simulates a state enter.</summary>
+    public void SetEnterState<TState>(TState state, LogicBlockState? previous = null)
+      where TState : LogicBlockState =>
+      _fakeSubject.Broadcast(new EnterStateBroadcast(state, previous));
 
     /// <summary>Simulates a state exit.</summary>
     public void SetExitState<TState>(TState state, LogicBlockState? next = null)

--- a/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
@@ -137,12 +137,12 @@ public partial class LogicBlock
       _fakeSubject.Broadcast(new StateBroadcast(state));
 
     /// <summary>Simulates a state enter.</summary>
-    public void SetEnterState<TState>(TState state, LogicBlockState? previous = null)
+    public void EnterState<TState>(TState state, LogicBlockState? previous = null)
       where TState : LogicBlockState =>
       _fakeSubject.Broadcast(new EnterStateBroadcast(state, previous));
 
     /// <summary>Simulates a state exit.</summary>
-    public void SetExitState<TState>(TState state, LogicBlockState? next = null)
+    public void ExitState<TState>(TState state, LogicBlockState? next = null)
       where TState : LogicBlockState =>
       _fakeSubject.Broadcast(new ExitStateBroadcast(state, next));
 

--- a/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.Binding.cs
@@ -124,9 +124,9 @@ public partial class LogicBlock
       _fakeSubject.Broadcast(new StateBroadcast(state, previous));
 
     /// <summary>Simulates a state exit.</summary>
-    public void ExitState<TState>(TState state, LogicBlockState? next = null)
+    public void SetExitState<TState>(TState state, LogicBlockState? next = null)
       where TState : LogicBlockState =>
-      _fakeSubject.Broadcast(new StateBroadcast(state, next));
+      _fakeSubject.Broadcast(new ExitStateBroadcast(state, next));
 
     /// <summary>Simulates an output being produced.</summary>
     public void Output<TOutput>(in TOutput output)

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -305,9 +305,7 @@ public abstract partial class LogicBlock : ILogicBlock,
   {
     // run the second half of a state change sequence since there's no state to exit
     var state = _state!;
-
-    state.Attach(this);
-    state.Enter(null); // runs user code
+    ChangeState(state, null);
 
     OnStart(); // runs user code
 
@@ -321,10 +319,6 @@ public abstract partial class LogicBlock : ILogicBlock,
     // announce that we've started
     _subject.Broadcast(new StartedBroadcast()); // runs user code
 
-    // also announce the state itself for any bindings that may be listening
-    _subject.Broadcast(new StateBroadcast(state)); // runs user code
-    _subject.Broadcast(new EnterStateBroadcast(state, null)); // runs user code
-
     if (op.IsLoading)
     {
       Loaded(); // AutoBlock extends this to run user code, OnLoad()
@@ -333,17 +327,33 @@ public abstract partial class LogicBlock : ILogicBlock,
     }
   }
 
+  private void ChangeState(LogicBlockState? nextState, LogicBlockState? previousState)
+  {
+    if (previousState is not null)
+    {
+      _state!.Exit(nextState); // runs user code
+      _subject.Broadcast(new ExitStateBroadcast(previousState, nextState)); // runs user code
+      _state.Detach();
+    }
+
+    _state = nextState;
+
+    if (nextState is not null)
+    {
+      nextState.Attach(this);
+      nextState.Enter(previousState); // runs user code
+      _subject.Broadcast(new StateBroadcast(nextState)); // runs user code
+      _subject.Broadcast(new EnterStateBroadcast(nextState, previousState)); // runs user code
+    }
+  }
+
   void IPerform<StopOp>.Perform(in StopOp op)
   {
     if (!IsStarted)
     { return; }
 
-    _state!.Exit(null); // runs user code
-    _state.Detach();
-
-    _subject.Perform(new ExitStateBroadcast(_state, null));
-
-    _state = null;
+    var previous = _state;
+    ChangeState(null, previous);
 
     OnStop();
     OnStopSubscriptions();
@@ -428,18 +438,7 @@ public abstract partial class LogicBlock : ILogicBlock,
     }
 
     var previous = _state;
-    previous!.Exit(state); // runs user code
-    previous.Detach();
-    _state = state;
-    state?.Attach(this);
-    state?.Enter(previous); // runs user code
-
-    if (state is not null)
-    {
-      _subject.Broadcast(new StateBroadcast(state));
-      _subject.Broadcast(new EnterStateBroadcast(state, previous));
-      _subject.Broadcast(new ExitStateBroadcast(previous, state));
-    }
+    ChangeState(state, previous);
   }
 
   #endregion AtomicOperations

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -322,7 +322,8 @@ public abstract partial class LogicBlock : ILogicBlock,
     _subject.Broadcast(new StartedBroadcast()); // runs user code
 
     // also announce the state itself for any bindings that may be listening
-    _subject.Broadcast(new StateBroadcast(state, null)); // runs user code
+    _subject.Broadcast(new StateBroadcast(state)); // runs user code
+    _subject.Broadcast(new EnterStateBroadcast(state, null)); // runs user code
 
     if (op.IsLoading)
     {
@@ -435,7 +436,8 @@ public abstract partial class LogicBlock : ILogicBlock,
 
     if (state is not null)
     {
-      _subject.Broadcast(new StateBroadcast(state, previous));
+      _subject.Broadcast(new StateBroadcast(state));
+      _subject.Broadcast(new EnterStateBroadcast(state, previous));
       _subject.Broadcast(new ExitStateBroadcast(previous, state));
     }
   }

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -327,26 +327,6 @@ public abstract partial class LogicBlock : ILogicBlock,
     }
   }
 
-  private void ChangeState(LogicBlockState? nextState, LogicBlockState? previousState)
-  {
-    if (previousState is not null)
-    {
-      _state!.Exit(nextState); // runs user code
-      _subject.Broadcast(new ExitStateBroadcast(previousState, nextState)); // runs user code
-      _state.Detach();
-    }
-
-    _state = nextState;
-
-    if (nextState is not null)
-    {
-      nextState.Attach(this);
-      nextState.Enter(previousState); // runs user code
-      _subject.Broadcast(new StateBroadcast(nextState)); // runs user code
-      _subject.Broadcast(new EnterStateBroadcast(nextState, previousState)); // runs user code
-    }
-  }
-
   void IPerform<StopOp>.Perform(in StopOp op)
   {
     if (!IsStarted)
@@ -439,6 +419,26 @@ public abstract partial class LogicBlock : ILogicBlock,
 
     var previous = _state;
     ChangeState(state, previous);
+  }
+
+  private void ChangeState(LogicBlockState? nextState, LogicBlockState? previousState)
+  {
+    if (previousState is not null)
+    {
+      _state!.Exit(nextState); // runs user code
+      _subject.Broadcast(new ExitStateBroadcast(previousState, nextState)); // runs user code
+      _state.Detach();
+    }
+
+    _state = nextState;
+
+    if (nextState is not null)
+    {
+      nextState.Attach(this);
+      nextState.Enter(previousState); // runs user code
+      _subject.Broadcast(new StateBroadcast(nextState)); // runs user code
+      _subject.Broadcast(new EnterStateBroadcast(nextState, previousState)); // runs user code
+    }
   }
 
   #endregion AtomicOperations

--- a/Chickensoft.LogicBlocks/src/LogicBlock.cs
+++ b/Chickensoft.LogicBlocks/src/LogicBlock.cs
@@ -322,7 +322,7 @@ public abstract partial class LogicBlock : ILogicBlock,
     _subject.Broadcast(new StartedBroadcast()); // runs user code
 
     // also announce the state itself for any bindings that may be listening
-    _subject.Broadcast(new StateBroadcast(state)); // runs user code
+    _subject.Broadcast(new StateBroadcast(state, null)); // runs user code
 
     if (op.IsLoading)
     {
@@ -339,6 +339,8 @@ public abstract partial class LogicBlock : ILogicBlock,
 
     _state!.Exit(null); // runs user code
     _state.Detach();
+
+    _subject.Perform(new ExitStateBroadcast(_state, null));
 
     _state = null;
 
@@ -433,7 +435,8 @@ public abstract partial class LogicBlock : ILogicBlock,
 
     if (state is not null)
     {
-      _subject.Broadcast(new StateBroadcast(state)); // runs user code
+      _subject.Broadcast(new StateBroadcast(state, previous));
+      _subject.Broadcast(new ExitStateBroadcast(previous, state));
     }
   }
 


### PR DESCRIPTION
Whenever we get the OnState feedback, it fires for each and every state change, even if it may be a substate

But when it comes to declaring this.OnEnter() or this.OnExit(), it only gets called if it is not of a derived type.

I've created a new OnEnter<TState> and OnExit<TState> so that we can get the same functionality on the logic block bindings as we do on the LogicBlockState.OnEnter() and LogicBlockState.OnExit()